### PR TITLE
Update to PROJ.4 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rust:
   - nightly
 before_install:
   - sudo apt-get update
-  - wget https://github.com/OSGeo/proj.4/releases/download/5.1.0/proj-6.0.0.tar.gz
+  - wget https://github.com/OSGeo/proj.4/releases/download/6.0.0/proj-6.0.0.tar.gz
   - tar -xzvf proj-6.0.0.tar.gz
   - pushd proj-6.0.0 && ./configure --prefix=/usr && make && sudo make install && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rust:
   - nightly
 before_install:
   - sudo apt-get update
-  - wget https://github.com/OSGeo/proj.4/releases/download/5.1.0/proj-5.1.0.tar.gz
-  - tar -xzvf proj-5.1.0.tar.gz
-  - pushd proj-5.1.0 && ./configure --prefix=/usr && make && sudo make install && popd
+  - wget https://github.com/OSGeo/proj.4/releases/download/5.1.0/proj-6.0.0.tar.gz
+  - tar -xzvf proj-6.0.0.tar.gz
+  - pushd proj-6.0.0 && ./configure --prefix=/usr && make && sudo make install && popd

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # Changes
+## 0.9.0
+* Update proj-sys to v0.9.0
+    * This requires a minimum PROJ.4 version of 6.0.0
+* Add support for `proj_create_crs_to_crs` for creating a transformation object that is a pipeline between two known coordinate reference systems.
 
 ## 0.7.0
 * Update proj-sys to v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for PROJ.4"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",
@@ -10,10 +10,11 @@ authors = [
 repository = "https://github.com/georust/proj"
 keywords = ["proj", "projection", "osgeo", "geo"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [dependencies]
-proj-sys = "0.8.0"
-geo-types ="0.2"
-libc = "0.2.39"
-num-traits = "0.2"
+proj-sys = "0.9.0"
+geo-types ="0.4.1"
+libc = "0.2.50"
+num-traits = "0.2.6"
 failure = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
-description = "Rust bindings for PROJ.4"
-version = "0.8.0"
+description = "Rust bindings for PROJ.4 v6.0.x"
+version = "0.9.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PROJ
 
-Rust bindings for [PROJ.4](https://github.com/OSGeo/proj.4), v5.2.x
+Rust bindings for [PROJ.4](https://github.com/OSGeo/proj.4), v6.0.x
 
 # Examples
 Note that as of v5.0.0, PROJ.4 uses the [`pipeline`](http://proj4.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The first example below works as follows:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ assert_almost_eq(result.x(), 1450880.29);
 assert_almost_eq(result.y(), 1141263.01);
 ```
 
-Note that as of v5.0.0, PROJ.4 uses the [`pipeline`](http://proj4.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The _second_ example below works as follows:
+Note that as of v5.0.0, PROJ.4 uses the [`pipeline`](http://proj4.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The example below works as follows:
 
 - define the operation as a `pipeline` operation
 - define `step` 1 as an `inv`erse transform, yielding geodetic coordinates

--- a/README.md
+++ b/README.md
@@ -3,13 +3,32 @@
 Rust bindings for [PROJ.4](https://github.com/OSGeo/proj.4), v6.0.x
 
 # Examples
-Note that as of v5.0.0, PROJ.4 uses the [`pipeline`](http://proj4.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The first example below works as follows:
+
+## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using EPSG Codes
+```rust
+extern crate proj;
+use proj::Proj;
+
+extern crate geo_types;
+use geo_types::Point;
+
+let from = "EPSG:2230";
+let to = "EPSG:26946";
+let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+let result = proj
+    .convert(Point::new(4760096.421921, 3744293.729449))
+    .unwrap();
+assert_almost_eq(result.x(), 1450880.29);
+assert_almost_eq(result.y(), 1141263.01);
+```
+
+Note that as of v5.0.0, PROJ.4 uses the [`pipeline`](http://proj4.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The _second_ example below works as follows:
 
 - define the operation as a `pipeline` operation
 - define `step` 1 as an `inv`erse transform, yielding geodetic coordinates
 - define `step` 2 as a forward transform to projected coordinates, yielding metres.
 
-## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946)
+## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using the `pipeline` Operator
 ```rust
 extern crate proj;
 use proj::Proj;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-//! `proj` provides bindings to the [proj.4](http://proj4.org), v5.0.x API
+//! `proj` provides bindings to the [PROJ.4](http://proj4.org), v6.0.x API
 //!
 //! Two coordinate operations are currently provided: projection (and inverse projection)
 //! and conversion. Projection is intended for transforming between geodetic and projected coordinates,
 //! and vice versa (inverse projection), while conversion is intended for transforming between projected
-//! coordinate systems. The proj.4 [documentation](http://proj4.org/operations/index.html)
+//! coordinate systems. The PROJ.4 [documentation](http://proj4.org/operations/index.html)
 //! explains the distinction between these operations.
 
 #[macro_use]
@@ -16,3 +16,4 @@ extern crate proj_sys;
 mod proj;
 
 pub use crate::proj::Proj;
+pub use crate::proj::Area;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,4 @@ extern crate proj_sys;
 
 mod proj;
 
-pub use proj::Proj;
+pub use crate::proj::Proj;

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -5,7 +5,7 @@ use libc::{c_char, c_double};
 use num_traits::Float;
 use proj_sys::proj_errno;
 use proj_sys::{
-    proj_errno_string, proj_context_create, proj_create, proj_create_crs_to_crs, proj_destroy,
+    proj_context_create, proj_create, proj_context_errno, proj_create_crs_to_crs, proj_destroy, proj_errno_string,
     proj_pj_info, proj_trans, PJconsts, PJ_AREA, PJ_COORD, PJ_DIRECTION_PJ_FWD,
     PJ_DIRECTION_PJ_INV, PJ_LP, PJ_XY,
 };
@@ -216,7 +216,8 @@ mod test {
         let stereo70 = Proj::new(
             "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000
             +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs",
-        ).unwrap();
+        )
+        .unwrap();
         // Geodetic -> Pulkovo 1942(58) / Stereo70 (EPSG 3844)
         let t = stereo70
             .project(Point::new(0.436332, 0.802851), false)
@@ -230,7 +231,8 @@ mod test {
         let stereo70 = Proj::new(
             "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000
             +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs",
-        ).unwrap();
+        )
+        .unwrap();
         // Pulkovo 1942(58) / Stereo70 (EPSG 3844) -> Geodetic
         let t = stereo70
             .project(Point::new(500119.70352012233, 500027.77896348457), true)
@@ -246,7 +248,8 @@ mod test {
             +proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy
             +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 +units=m +no_defs
             ",
-        ).unwrap();
+        )
+        .unwrap();
         // OSGB36 (EPSG 27700) -> Geodetic
         let t = osgb36
             .project(Point::new(548295.39, 182498.46), true)
@@ -283,10 +286,9 @@ mod test {
     fn test_conversion_error() {
         // because step 1 isn't an inverse conversion, it's expecting lon lat input
         let nad83_m = Proj::new(
-            "
-            +proj=geos +lon_0=0.00 +lat_0=0.00 +a=6378169.00 +b=6356583.80 +h=35785831.0
-        ",
-        ).unwrap();
+            "+proj=geos +lon_0=0.00 +lat_0=0.00 +a=6378169.00 +b=6356583.80 +h=35785831.0"
+        )
+        .unwrap();
         let err = nad83_m
             .convert(Point::new(4760096.421921, 3744293.729449))
             .unwrap_err();

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -51,6 +51,16 @@ fn error_message(code: c_int) -> String {
     _string(rv)
 }
 
+/// Set the bounding box of the area of use
+fn area_set_bbox(parea: *mut proj_sys::PJ_AREA, new_area: Option<Area>) {
+    // if a bounding box has been passed, modify the proj area object
+    if let Some(narea) = new_area {
+        unsafe {
+            proj_area_set_bbox(parea, narea.west, narea.south, narea.east, narea.north);
+        }
+    }
+}
+
 /// A `PROJ.4` instance
 pub struct Proj {
     c_proj: *mut PJconsts,
@@ -105,7 +115,7 @@ impl Proj {
     ///
     /// extern crate geo_types;
     /// use geo_types::Point;
-    /// 
+    ///
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
     /// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
@@ -275,16 +285,6 @@ impl Proj {
                 "The conversion failed with the following error: {}",
                 error_message(err)
             ))
-        }
-    }
-}
-
-/// Set the bounding box of the area of use
-fn area_set_bbox(parea: *mut proj_sys::PJ_AREA, new_area: Option<Area>) {
-    // if a bounding box has been passed, modify the proj area object
-    if let Some(narea) = new_area {
-        unsafe {
-            proj_area_set_bbox(parea, narea.west, narea.south, narea.east, narea.north);
         }
     }
 }

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -103,7 +103,7 @@ impl Proj {
     /// Create a transformation object that is a pipeline between two known coordinate reference systems.
     /// `from` and `to` can be:
     ///
-    /// - an “AUTHORITY:CODE”, like `"EPSG:25832"`. When using that syntax for a source CRS, the created pipeline will expect that the values passed to [`project()`](struct.Proj.html#method.project) or [`convert()`](struct.Proj.html#method.convert) respect the axis order and axis unit of the official definition ( so for example, for EPSG:4326, with latitude first and longitude next, in degrees). Similarly, when using that syntax for a target CRS, output values will be emitted according to the official definition of this CRS.
+    /// - an `"AUTHORITY:CODE"`, like `"EPSG:25832"`. When using that syntax for a source CRS, the created pipeline will expect that the values passed to [`project()`](struct.Proj.html#method.project) or [`convert()`](struct.Proj.html#method.convert) respect the axis order and axis unit of the official definition ( so for example, for EPSG:4326, with latitude first and longitude next, in degrees). Similarly, when using that syntax for a target CRS, output values will be emitted according to the official definition of this CRS.
     /// - a PROJ string, like `"+proj=longlat +datum=WGS84"`. When using that syntax, the axis order and unit for geographic CRS will be longitude, latitude, and the unit degrees.
     /// - the name of a CRS as found in the PROJ database, e.g `"WGS84"`, `"NAD27"`, etc.
     /// - more generally, any string accepted by [`new()`](struct.Proj.html#method.new)

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -66,6 +66,9 @@ impl Proj {
     ///
     /// For conversion operations, `definition` defines input, output, and
     /// any intermediate steps that are required. See the `convert` example for more details.
+    ///
+    /// # Safety
+    /// This method contains unsafe code.
 
     // In contrast to proj.4 v4.x, the type of transformation
     // is signalled by the choice of enum used as input to the PJ_COORD union
@@ -112,6 +115,9 @@ impl Proj {
     /// assert_almost_eq(result.x(), 1450880.29);
     /// assert_almost_eq(result.y(), 1141263.01);
     ///```
+    ///
+    /// # Safety
+    /// This method contains unsafe code.
     pub fn new_known_crs(from: &str, to: &str, area: Option<Area>) -> Option<Proj> {
         let from_c = CString::new(from.as_bytes()).unwrap();
         let to_c = CString::new(to.as_bytes()).unwrap();
@@ -136,6 +142,9 @@ impl Proj {
     /// for the choice of relevant coordinate operations.
     /// In the case of an area of use crossing the antimeridian (longitude +/- 180 degrees),
     /// `west` must be greater than `east`.
+    ///
+    /// # Safety
+    /// This method contains unsafe code.
     // calling this on a non-CRS-to-CRS instance of Proj will be harmless, because self.area will be None
     pub fn area_set_bbox(&mut self, new_area: Option<Area>) {
         if let (Some(proj_area), Some(new_bbox)) = (self.area, new_area) {
@@ -152,6 +161,9 @@ impl Proj {
     }
 
     /// Get the current definition from `PROJ.4`
+    ///
+    /// # Safety
+    /// This method contains unsafe code.
     pub fn def(&self) -> String {
         let rv = unsafe { proj_pj_info(self.c_proj) };
         _string(rv.definition)
@@ -160,6 +172,9 @@ impl Proj {
     ///
     /// **Note:** specifying `inverse` as `true` carries out an inverse projection *to* geodetic coordinates
     /// (in radians) from the projection specified by `definition`.
+    ///
+    /// # Safety
+    /// This method contains unsafe code.
     pub fn project<T>(&self, point: Point<T>, inverse: bool) -> Result<Point<T>, Error>
     where
         T: Float,
@@ -234,6 +249,9 @@ impl Proj {
     /// assert_eq!(result.y(), 1141263.01);
     ///
     /// ```
+    ///
+    /// # Safety
+    /// This method contains unsafe code.
     pub fn convert<T>(&self, point: Point<T>) -> Result<Point<T>, Error>
     where
         T: Float,

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -148,10 +148,10 @@ impl Proj {
 
     /// Set the bounding box of the area of use
     ///
-    /// Such an area of use will be used to specify the area of use
+    /// This bounding box will be used to specify the area of use
     /// for the choice of relevant coordinate operations.
     /// In the case of an area of use crossing the antimeridian (longitude +/- 180 degrees),
-    /// `west` must be greater than `east`.
+    /// `west` **must** be greater than `east`.
     ///
     /// # Safety
     /// This method contains unsafe code.


### PR DESCRIPTION
PROJ.4 v6.0.x has been released and is widely available. Notably, it has support for EPSG strings (and much more besides) for defining conversions, so PROJ strings are no longer needed for many operations.