### PR TITLE
Normalise input and output coordinate order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 0.14.0
+* Normalise input and output coordinate order to Lat, Lon / Easting, Northing for conversions between known CRS (#21)
+
 ## 0.13.0
 * Updated to proj-sys 0.12.0 (PROJ 6.3)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //! explains the distinction between these operations.
 //!
 //! Anything that can be converted into a [`geo-types`](https://docs.rs/geo-types) `Point` via the `Into`
-//! trait can be used as input for the conversion or transformation function, and conversion of a slice of
-//! `Point`s between known CRS is also supported.
+//! trait can be used as input for the conversion or transformation functions, and conversion of a slice of
+//! `Point`s [is also supported](struct.Proj.html#method.convert_array).
 //!
 //! # Example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,17 @@
-//! `proj` provides bindings to the [PROJ](http://proj.org) v6.2.x API
+#![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
+//! `proj` provides bindings to the [PROJ](https://proj.org) v6.3.x API
 //!
 //! Two coordinate operations are currently provided: [projection](struct.Proj.html#method.project)
 //! (and inverse projection)
 //! and [conversion](struct.Proj.html#method.convert).
-//! Projection is intended for transforming between geodetic and projected coordinates,
-//! and vice versa (inverse projection), while conversion is intended for transforming between projected
-//! coordinate systems. The PROJ [documentation](http://proj.org/operations/index.html)
+//! Projection is intended for transformations between geodetic and projected coordinates,
+//! and vice versa (inverse projection), while conversion is intended for transformations between projected
+//! coordinate systems. The PROJ [documentation](https://proj.org/operations/index.html)
 //! explains the distinction between these operations.
 //!
 //! Anything that can be converted into a [`geo-types`](https://docs.rs/geo-types) `Point` via the `Into`
-//! trait can be used as input for the conversion or transformation function.
+//! trait can be used as input for the conversion or transformation function, and conversion of a slice of
+//! `Point`s between known CRS is also supported.
 //!
 //! # Example
 //!

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -248,13 +248,21 @@ impl Proj {
         }
     }
 
-    /// Convert coordinates using the PROJ `pipeline` operator
+    /// Convert projected coordinates between coordinate reference systems.
     ///
-    /// This method makes use of the [`pipeline`](http://proj4.org/operations/pipeline.html)
-    /// functionality available since v5.0.0, which differs significantly from the v4.x series
+    /// Input and output CRS may be specified in two ways:
+    /// 1. Using the PROJ `pipeline` operator. This method makes use of the [`pipeline`](http://proj4.org/operations/pipeline.html)
+    /// functionality available since `PROJ` 5. 
+    /// This has the advantage of being able to chain an arbitrary combination of projection, conversion,
+    /// and transformation steps, allowing for extremely complex operations ([`new`](#method.new))
+    /// 2. Using EPSG codes or `PROJ` strings to define input and output CRS ([`new_known_crs`](#method.new_known_crs))
     ///
-    /// It has the advantage of being able to chain an arbitrary combination of projection, conversion,
-    /// and transformation steps, allowing for extremely complex operations.
+    /// ## A Note on Coordinate Order
+    /// Depending on the method used to instantiate the `Proj` object, coordinate input and output order may vary:
+    /// - If you have used [`new`](#method.new), it is assumed that you've specified the order using the input string,
+    /// or that you are aware of the required input order and expected output order.
+    /// - If you have used [`new_known_crs`](#method.new_known_crs), input and output order are **normalised**
+    /// to Longitude, Latitude / Easting, Northing.
     ///
     /// The following example converts from NAD83 US Survey Feet (EPSG 2230) to NAD83 Metres (EPSG 26946)
     /// Note the steps:
@@ -315,7 +323,8 @@ impl Proj {
         }
     }
 
-    /// Convert a mutable slice (or anything that can deref into a mutable slice) of coordinates  
+    /// Convert a mutable slice (or anything that can deref into a mutable slice) of `Point`s
+    ///
     /// The following example converts from NAD83 US Survey Feet (EPSG 2230) to NAD83 Metres (EPSG 26946)
     ///
     /// ## A Note on Coordinate Order

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -115,8 +115,8 @@ impl Proj {
     /// Create a transformation object that is a pipeline between two known coordinate reference systems.
     /// `from` and `to` can be:
     ///
-    /// - an `"AUTHORITY:CODE"`, like `"EPSG:25832"`. When using that syntax for a source CRS, the created pipeline will expect that the values passed to [`project()`](struct.Proj.html#method.project) or [`convert()`](struct.Proj.html#method.convert) respect the axis order and axis unit of the official definition ( so for example, for EPSG:4326, with latitude first and longitude next, in degrees). Similarly, when using that syntax for a target CRS, output values will be emitted according to the official definition of this CRS.
-    /// - a PROJ string, like `"+proj=longlat +datum=WGS84"`. When using that syntax, the axis order and unit for geographic CRS will be longitude, latitude, and the unit degrees.
+    /// - an `"AUTHORITY:CODE"`, like `"EPSG:25832"`.
+    /// - a PROJ string, like `"+proj=longlat +datum=WGS84"`. When using that syntax, the unit is expected to be degrees.
     /// - the name of a CRS as found in the PROJ database, e.g `"WGS84"`, `"NAD27"`, etc.
     /// - more generally, any string accepted by [`new()`](struct.Proj.html#method.new)
     ///
@@ -124,11 +124,14 @@ impl Proj {
     /// ## A Note on Coordinate Order
     /// The required input **and** output coordinate order is **normalised** to `Longitude, Latitude` / `Easting, Northing`.
     ///
-    /// This overrides the expected order of a given CRS if necessary. See the [PROJ API](https://proj.org/development/reference/functions.html#c.proj_normalize_for_visualization)
+    /// This overrides the expected order of the specified input and / or output CRS if necessary.
+    /// See the [PROJ API](https://proj.org/development/reference/functions.html#c.proj_normalize_for_visualization)
     ///
     /// For example: per its definition, EPSG:4326 has an axis order of Latitude, Longitude. Without
-    /// normalisation, crate users would have to remember to reverse the coordinates of `Point` or `Coordinate` structs
-    /// in order for a conversion operation to return correct results.
+    /// normalisation, crate users would have to
+    /// [remember](https://proj.org/development/reference/functions.html#c.proj_create_crs_to_crs)
+    /// to reverse the coordinates of `Point` or `Coordinate` structs in order for a conversion operation to
+    /// return correct results.
     ///
     ///```rust
     /// # use assert_approx_eq::assert_approx_eq;


### PR DESCRIPTION
When transforming between two known CRS, input and output
coordinate order is now normalised to Lat, Lon / Easting Northing.

Note that this normalisation step is only applied to conversion operations between two known CRS (e.g. those that call [proj_create_crs_to_crs](https://proj.org/development/reference/functions.html#c.proj_create_crs_to_crs)), as per the PROJ API.