### PR TITLE
Re-export the bundled_proj feature of proj-sys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 language: rust
+
 rust:
   - stable
   - beta
   - nightly
+
+matrix:
+  include:
+    - env: PROJ_FEATURES=""
+    - env: PROJ_FEATURES="--features bundled_proj"
+
 before_install:
   - sudo apt-get update
   - wget https://download.osgeo.org/proj/proj-7.0.0.tar.gz
   - tar -xzvf proj-7.0.0.tar.gz
   - pushd proj-7.0.0 && ./configure --prefix=/usr && make && sudo make install && popd
+
+script:
+  - (cargo build --release $PROJ_FEATURES && cargo test --release $PROJ_FEATURES)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 # Changes
+
+## 0.16.0
+* Update to proj-sys v0.14.0
+* Re-export the bundled_proj feature introduced in proj-sys v0.14.0
+
 ## 0.15.0
 * Update to proj-sys v0.13.0
 * Update to use PROJ v7.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.15.1"
+version = "0.16.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",
@@ -15,11 +15,14 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-proj-sys = "0.13.0"
+proj-sys = "0.14.0"
 geo-types ="0.4.3"
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"
+
+[features]
+bundled_proj = [ "proj-sys/bundled_proj" ]
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 High-level Rust bindings for the latest stable version of [PROJ](https://github.com/OSGeo/proj) (7.0.x), compatible with the [Georust](https://crates.io/geo) ecosystem.
 
+# Requirements
+
+Sqlite3 must be present on your system.
+
+By default, this crate depends on a pre-built library, so PROJ v7.0.x must be present on your system. While this crate may be backwards-compatible with older PROJ 6 versions, this is neither tested nor supported.
+
+You can also choose to link against a PROJ included with (and built from source by) the `proj-sys` crate, upon which this crate is built. To do so, enable the `bundled_proj` Cargo feature. Currently this feature only supports Linux.
+
 # Examples
 
 ## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using EPSG Codes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,18 @@
 //! for [conversion](struct.Proj.html#method.convert_array) and [projection](struct.Proj.html#method.project_array)
 //! of slices of `Point`s are available.
 //!
+//! # Requirements
+//!
+//! Sqlite3 must be present on your system.
+//!
+//! By default, this crate depends on a pre-built library, so PROJ v7.0.x must be present on your
+//! system. While this crate may be backwards-compatible with older PROJ 6 versions, this is neither
+//! tested nor supported.
+//!
+//! You can also choose to link against a PROJ included with (and built from source by) the
+//! `proj-sys` crate, upon which this crate is built. To do so, enable the `bundled_proj` Cargo
+//! feature. Currently this feature only supports Linux.
+//!
 //! # Example
 //!
 //! ```


### PR DESCRIPTION
# Summary

Re-exports the `bundled_proj` feature of the underlying `proj-sys` crate. The feature causes `proj-sys` to internally compile and link against PROJ from sources included as a submodule.

Sibling PR of https://github.com/georust/proj-sys/pull/9