### PR TITLE
Updated Cargo.toml to use the latest version of 'geo-types'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # Changes
+
+## 0.16.0
+* Update to geo-types v0.5.0
+
 ## 0.15.0
 * Update to proj-sys v0.13.0
 * Update to use PROJ v7.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.15.1"
+version = "0.16.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 proj-sys = "0.13.0"
-geo-types ="0.4.3"
+geo-types ="0.5.0"
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"


### PR DESCRIPTION
First potential contribution to a Rust library.

I've been using the geo, geojson and now the proj crate but I've found there is a conflict of version. Proj is using an older version as I'm getting an error which says `perhaps two different versions of crate geo_types are being used?`

