### PR TITLE
Enable native network functionality without requiring libcurl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,13 @@
 # Changes
 
+## 0.20.0
+* Add network control and grid download functionality
+
 ## 0.19.0
 * Update to proj-sys 0.17.1
 
 ## 0.18.0
 * Bump geo-types
-
-## 0.17.2
-* add network control functionality
 
 ## 0.17.1
 * Fix docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ geo-types ="0.6.0"
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"
-reqwest = { version = "0.10.6", features = ["blocking"] }
+reqwest = { version = "0.10.6", features = ["blocking", "rustls-tls"] }
 
 [features]
 bundled_proj = [ "proj-sys/bundled_proj" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.19.0"
+version = "0.20.0"
 authors = [
-  "Corey Farwell <coreyf@rwell.org>",
-  "Alex Morega <alex@grep.ro>",
-  "Stephan Hügel <urschrei@gmail.com>"
+    "The Georust Developers <mods@georust.org>"
 ]
 repository = "https://github.com/georust/proj"
 documentation = "https://docs.rs/proj/"
@@ -20,6 +18,7 @@ geo-types ="0.6.0"
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"
+reqwest = { version = "0.10.6", features = ["blocking"] }
 
 [features]
 bundled_proj = [ "proj-sys/bundled_proj" ]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ use geo_types::Point;
 
 let from = "EPSG:2230";
 let to = "EPSG:26946";
-let ft_to_m = Proj::new_known_crs(&from, &to, None, false).unwrap();
+let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 let result = ft_to_m
     .convert(Point::new(4760096.421921, 3744293.729449))
     .unwrap();
@@ -76,7 +76,7 @@ let stereo70 = Proj::new("
     +proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000
     +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84
     +units=m +no_defs
-    ", false).unwrap();
+    ").unwrap();
 let rp = stereo70.project(
     Point::new(500119.70352012233, 500027.77896348457), true
 ).unwrap();

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PROJ
 
-High-level Rust bindings for the latest stable version of [PROJ](https://github.com/OSGeo/proj) (7.1.x), compatible with the [Georust](https://crates.io/geo) ecosystem.
+High-level Rust bindings for the latest stable version of [PROJ](https://github.com/OSGeo/proj) (7.1.x), compatible with the [Georust](https://crates.io/geo) ecosystem. Includes network grid download functionality.
 
 # Requirements
 
@@ -26,7 +26,7 @@ use geo_types::Point;
 
 let from = "EPSG:2230";
 let to = "EPSG:26946";
-let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+let ft_to_m = Proj::new_known_crs(&from, &to, None, false).unwrap();
 let result = ft_to_m
     .convert(Point::new(4760096.421921, 3744293.729449))
     .unwrap();
@@ -56,7 +56,7 @@ let ft_to_m = Proj::new("
     +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666
     +lon_0=-116.25 +x_0=2000000 +y_0=500000
     +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
-").unwrap();
+", false).unwrap();
 // The Presidio, approximately
 let result = ft_to_m.convert(Point::new(4760096.421921, 3744293.729449)).unwrap();
 assert_eq!(result.x(), 1450880.29);
@@ -76,7 +76,7 @@ let stereo70 = Proj::new("
     +proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000
     +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84
     +units=m +no_defs
-    ").unwrap();
+    ", false).unwrap();
 let rp = stereo70.project(
     Point::new(500119.70352012233, 500027.77896348457), true
 ).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,29 +19,29 @@
 //! 1. If you don't require additional grids or other customisation:
 //!     - Call `Proj::new` or `Proj::new_known_crs`. This creates a transformation instance ([`Proj`](proj/struct.Proj.html))
 //! 2. If you require a grid for the transformation you wish to carry out, or you need to customise the search path or the grid endpoint:
-//!     - Create a new [`TransformBuilder`](proj/struct.TransformBuilder.html) by calling `TransformBuilder::new()`. It may be modified to enable network downloads, disable the grid, cache or modify search paths;
-//!     - Call [`TransformBuilder.proj()`](proj/struct.TransformBuilder.html#method.proj) or [`TransformBuilder.transform_known_crs()`](proj/struct.TransformBuilder.html#method.transform_known_crs). This creates a transformation instance (`Proj`)
+//!     - Create a new [`ProjBuilder`](proj/struct.ProjBuilder.html) by calling `ProjBuilder::new()`. It may be modified to enable network downloads, disable the grid, cache or modify search paths;
+//!     - Call [`ProjBuilder.proj()`](proj/struct.ProjBuilder.html#method.proj) or [`ProjBuilder.transform_known_crs()`](proj/struct.ProjBuilder.html#method.transform_known_crs). This creates a transformation instance (`Proj`)
 //!
 //! **Note**:
 //!
-//! 1. Both `TransformBuilder` and `Proj` implement the [`Info`](proj/trait.Info.html) trait, which can be used to get information about the current state of the `PROJ` instance;
-//! 2. `Proj::new()` and `TransformBuilder::proj()` have the same signature;
-//! 3. `Proj::new_known_crs()` and `TransformBuilder::transform_known_crs()` have the same signature.
+//! 1. Both `ProjBuilder` and `Proj` implement the [`Info`](proj/trait.Info.html) trait, which can be used to get information about the current state of the `PROJ` instance;
+//! 2. `Proj::new()` and `ProjBuilder::proj()` have the same signature;
+//! 3. `Proj::new_known_crs()` and `ProjBuilder::transform_known_crs()` have the same signature.
 //!
 //! ## Network, Cache, and Search Path Functionality
 //!
 //! ### Grid File Download
 //! `proj` supports [network grid download](https://proj.org/usage/network.html) functionality.
 //! Network access is **disabled** by default, and
-//! can be activated by passing a `true` `bool` to [`enable_network()`](proj/struct.Context.html#method.enable_network).
+//! can be activated by passing a `true` `bool` to [`enable_network()`](proj/struct.ProjBuilder.html#method.enable_network).
 //! Network functionality status can be queried with
 //! `network_enabled`, and the download endpoint can be queried and set using `get_url_endpoint` and `set_url_endpoint`.
 //!
 //! #### Grid File Cache
-//! Up to 300 mb of downloaded grids are cached to save bandwidth: This cache can be enabled or disabled using [`grid_cache_enable`](proj/struct.Context.html#method.grid_cache_enable).
+//! Up to 300 mb of downloaded grids are cached to save bandwidth: This cache can be enabled or disabled using [`grid_cache_enable`](proj/struct.ProjBuilder.html#method.grid_cache_enable).
 //!
 //! ### Search Path Modification
-//! The path used to search for resource files can be modified using [`set_search_paths`](proj/struct.Context.html#method.set_search_paths)
+//! The path used to search for resource files can be modified using [`set_search_paths`](proj/struct.ProjBuilder.html#method.set_search_paths)
 //!
 //!
 //! # Requirements
@@ -81,7 +81,7 @@ mod network;
 mod proj;
 
 pub use crate::proj::Area;
-pub use crate::proj::TransformBuilder;
+pub use crate::proj::ProjBuilder;
 pub use crate::proj::Info;
 pub use crate::proj::Proj;
 pub use crate::proj::ProjError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,13 @@
 //!     - Call `Proj::new` or `Proj::new_known_crs`. This creates a transformation instance ([`Proj`](proj/struct.Proj.html))
 //! 2. If you require a grid for the transformation you wish to carry out, or you need to customise the search path or the grid endpoint:
 //!     - Create a new [`ProjBuilder`](proj/struct.ProjBuilder.html) by calling `ProjBuilder::new()`. It may be modified to enable network downloads, disable the grid, cache or modify search paths;
-//!     - Call [`ProjBuilder.proj()`](proj/struct.ProjBuilder.html#method.proj) or [`ProjBuilder.transform_known_crs()`](proj/struct.ProjBuilder.html#method.transform_known_crs). This creates a transformation instance (`Proj`)
+//!     - Call [`ProjBuilder.proj()`](proj/struct.ProjBuilder.html#method.proj) or [`ProjBuilder.proj_known_crs()`](proj/struct.ProjBuilder.html#method.proj_known_crs). This creates a transformation instance (`Proj`)
 //!
 //! **Note**:
 //!
 //! 1. Both `ProjBuilder` and `Proj` implement the [`Info`](proj/trait.Info.html) trait, which can be used to get information about the current state of the `PROJ` instance;
 //! 2. `Proj::new()` and `ProjBuilder::proj()` have the same signature;
-//! 3. `Proj::new_known_crs()` and `ProjBuilder::transform_known_crs()` have the same signature.
+//! 3. `Proj::new_known_crs()` and `ProjBuilder::proj_known_crs()` have the same signature.
 //!
 //! ## Network, Cache, and Search Path Functionality
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,12 @@
 //!     - Call `Proj::new` or `Proj::new_known_crs`. This creates a transformation instance ([`Proj`](proj/struct.Proj.html))
 //! 2. If you require a grid for the transformation you wish to carry out, or you need to customise the search path or the grid endpoint:
 //!     - Create a new [`TransformBuilder`](proj/struct.TransformBuilder.html) by calling `TransformBuilder::new()`. It may be modified to enable network downloads, disable the grid, cache or modify search paths;
-//!     - Call [`TransformBuilder.transform()`](proj/struct.TransformBuilder.html#method.transform) or [`TransformBuilder.transform_known_crs()`](proj/struct.TransformBuilder.html#method.transform_known_crs). This creates a transformation instance (`Proj`)
+//!     - Call [`TransformBuilder.proj()`](proj/struct.TransformBuilder.html#method.proj) or [`TransformBuilder.transform_known_crs()`](proj/struct.TransformBuilder.html#method.transform_known_crs). This creates a transformation instance (`Proj`)
 //!
 //! **Note**:
 //!
 //! 1. Both `TransformBuilder` and `Proj` implement the [`Info`](proj/trait.Info.html) trait, which can be used to get information about the current state of the `PROJ` instance;
-//! 2. `Proj::new()` and `TransformBuilder::transform()` have the same signature;
+//! 2. `Proj::new()` and `TransformBuilder::proj()` have the same signature;
 //! 3. `Proj::new_known_crs()` and `TransformBuilder::transform_known_crs()` have the same signature.
 //!
 //! ## Network, Cache, and Search Path Functionality

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,8 @@ mod network;
 mod proj;
 
 pub use crate::proj::Area;
-pub use crate::proj::ProjBuilder;
 pub use crate::proj::Info;
 pub use crate::proj::Proj;
+pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjError;
 pub use crate::proj::Projinfo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,18 @@
 //! for [conversion](struct.Proj.html#method.convert_array) and [projection](struct.Proj.html#method.project_array)
 //! of slices of `Point`s are available.
 //!
-//! ## Other Features
+//! ## Network Functionality
 //!
 //! `proj` supports [network grid download](https://proj.org/usage/network.html) functionality.
-//! Modifying the download CDN endpoint is **not** currently supported. Network access is **disabled** by default, and
-//! can be activated by passing a `true` `bool` to [`Proj::new()`](struct.Proj.html#method.new) or
-//! [`Proj::new_known_crs()`](struct.Proj.html#method.new_known_crs). Network functionality status can be queried with
-//! `Proj::network_enabled`.
+//! Network access is **disabled** by default, and
+//! can be activated by passing a `true` `bool` to [`enable_network()`](fn.enable_network.html).
+//! Network functionality status can be queried with
+//! `network_enabled`, and the download endpoint can be queried and set using `get_url_endpoint` and `set_url_endpoint`.
+//!
+//! ### Note:
+//! Changes to network settings only affect _subsequent_ `Proj` instances.
+//! For example: if you create a new transformation instance, _then_ call `enable_network`,
+//! No grid download will be attempted for that instance.
 //!
 //! # Requirements
 //!
@@ -47,7 +52,7 @@
 //!
 //! let from = "EPSG:2230";
 //! let to = "EPSG:26946";
-//! let nad_ft_to_m = Proj::new_known_crs(&from, &to, None, false).unwrap();
+//! let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 //! let result = nad_ft_to_m
 //!     .convert(Point::new(4760096.421921f64, 3744293.729449f64))
 //!     .unwrap();
@@ -58,6 +63,11 @@
 mod network;
 mod proj;
 
+pub use crate::proj::enable_network;
+pub use crate::proj::get_url_endpoint;
+pub use crate::proj::grid_cache_set_enable;
+pub use crate::proj::network_enabled;
+pub use crate::proj::set_url_endpoint;
 pub use crate::proj::Area;
 pub use crate::proj::Proj;
 pub use crate::proj::ProjError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,14 @@
 //! for [conversion](struct.Proj.html#method.convert_array) and [projection](struct.Proj.html#method.project_array)
 //! of slices of `Point`s are available.
 //!
+//! ## Other Features
+//!
+//! `proj` supports [network grid download](https://proj.org/usage/network.html) functionality.
+//! Modifying the download CDN endpoint is **not** currently supported. Network access is **disabled** by default, and
+//! can be activated by passing a `true` `bool` to [`Proj::new()`](struct.Proj.html#method.new) or
+//! [`Proj::new_known_crs()`](struct.Proj.html#method.new_known_crs). Network functionality status can be queried with
+//! `Proj::network_enabled`.
+//!
 //! # Requirements
 //!
 //! By default, this requires `libproj` 7.0.x to be present on your system. While this crate may be backwards-compatible with older PROJ 6 versions, this is neither tested nor supported.
@@ -39,7 +47,7 @@
 //!
 //! let from = "EPSG:2230";
 //! let to = "EPSG:26946";
-//! let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+//! let nad_ft_to_m = Proj::new_known_crs(&from, &to, None, false).unwrap();
 //! let result = nad_ft_to_m
 //!     .convert(Point::new(4760096.421921f64, 3744293.729449f64))
 //!     .unwrap();
@@ -47,6 +55,7 @@
 //! assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
 //! ```
 
+mod network;
 mod proj;
 
 pub use crate::proj::Area;

--- a/src/network.rs
+++ b/src/network.rs
@@ -238,6 +238,9 @@ fn _network_get_header_value(
         .to_str()?;
     let cstr = CString::new(hvalue).unwrap();
     let header = cstr.into_raw();
+    // Raw pointers are Copy: the pointer returned by this function is never returned by libproj,so
+    // in order to avoid a memory leak, the pointer is copied and stored in the HandleData struct,
+    // which is dropped in close_network. As part of that, the pointer in hptr is returned to Rust
     hd.hptr = Some(header);
     Ok(header)
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -72,9 +72,9 @@ fn error_handler<'a>(
     // Check whether something went wrong on the server, or if it's an S3 retry code
     if res.status().is_server_error() || RETRY_CODES.contains(&status) {
         // Start retrying: up to MAX_RETRIES
-        while res.status().is_server_error()
-            || RETRY_CODES.contains(&status)
-            || retries <= MAX_RETRIES
+        while (res.status().is_server_error()
+            || RETRY_CODES.contains(&status))
+            && retries <= MAX_RETRIES
         {
             retries += 1;
             let wait = time::Duration::from_millis(get_wait_time_exp(retries as i32));

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,369 @@
+/// A module for native grid network functionality, so we don't have to depend on libcurl
+/// The crate-public functions are facades – they're designed for interaction with libproj –
+/// delegating actual functionality to non-public versions, prefixed by an underscore.
+///
+/// **Note**: `error_string_max_size` is set to 128 by libproj.
+// TODO: build some length checks for the errors that are stuffed into it
+use proj_sys::{proj_context_set_network_callbacks, PJ_CONTEXT, PROJ_NETWORK_HANDLE};
+
+use reqwest::blocking::Client;
+use reqwest::Method;
+use std::ffi::CString;
+use std::os::raw::c_ulonglong;
+use std::ptr;
+
+use crate::proj::{ProjError, _string};
+use libc::c_char;
+use libc::c_void;
+use std::boxed::Box;
+use std::{thread, time};
+
+const CLIENT: &str = concat!("proj-rs/", env!("CARGO_PKG_VERSION"));
+const MAX_RETRIES: u8 = 8;
+
+/// This struct is cast to `c_void`, then to `PROJ_NETWORK_HANDLE` so it can be passed around
+#[no_mangle]
+struct HandleData {
+    client: reqwest::blocking::RequestBuilder,
+    headers: reqwest::header::HeaderMap,
+    // this raw pointer is returned to libproj but never returned from libproj,
+    // so a copy of the pointer (raw pointers are Copy) is stored here, so it can be
+    // reconstituted and dropped in network_close.
+    // Note to future self: are you 100% sure that the pointer is never read again
+    // after network_close returns?
+    hptr: Option<*const c_char>,
+}
+
+impl HandleData {
+    fn new(
+        client: reqwest::blocking::RequestBuilder,
+        headers: reqwest::header::HeaderMap,
+        hptr: Option<*const c_char>,
+    ) -> Self {
+        Self {
+            client,
+            headers,
+            hptr,
+        }
+    }
+}
+
+/// Return an exponential wait time based on the number of retries
+///
+/// Example: a value of 8 allows up to 6400 ms of retry delay, for a cumulative total of 25500 ms
+fn get_wait_time_exp(retrycount: i32) -> u64 {
+    if retrycount == 0 {
+        return 0;
+    }
+    (retrycount as u64).pow(2) * 100u64
+}
+
+/// Network callback: open
+///
+/// Should try to read the `size_to_read` first bytes at the specified offset of the file given by
+/// URL url, and write them to `buffer`. `out_size_read` should be updated with the actual amount
+/// of bytes read (== `size_to_read` if the file is larger than `size_to_read`). During this read,
+/// the implementation should make sure to store the HTTP headers from the server response to be
+/// able to respond to `proj_network_get_header_value_cbk_type` callback.
+/// `error_string_max_size` should be the maximum size that can be written into the `out_error_string`
+/// buffer (including terminating nul character).
+///
+/// Note that this function is a facade for _network_open
+pub(crate) unsafe extern "C" fn network_open(
+    pc: *mut PJ_CONTEXT,
+    url: *const c_char,
+    offset: c_ulonglong,
+    size_to_read: usize,
+    buffer: *mut c_void,
+    out_size_read: *mut usize,
+    error_string_max_size: usize,
+    out_error_string: *mut c_char,
+    ud: *mut c_void,
+) -> *mut PROJ_NETWORK_HANDLE {
+    match _network_open(
+        pc,
+        url,
+        offset,
+        size_to_read,
+        buffer,
+        out_size_read,
+        error_string_max_size,
+        out_error_string,
+        ud,
+    ) {
+        Ok(res) => res,
+        Err(e) => {
+            let err_string = e.to_string();
+            out_error_string.copy_from_nonoverlapping(err_string.as_ptr().cast(), err_string.len());
+            out_error_string.add(err_string.len()).write(0);
+            ptr::null_mut() as *mut PROJ_NETWORK_HANDLE
+        }
+    }
+}
+
+/// Where the ACTUAL work happens, taking advantage of Rust error-handling etc
+fn _network_open(
+    _: *mut PJ_CONTEXT,
+    url: *const c_char,
+    offset: c_ulonglong,
+    size_to_read: usize,
+    buffer: *mut c_void,
+    out_size_read: *mut usize,
+    _: usize,
+    out_error_string: *mut c_char,
+    _: *mut c_void,
+) -> Result<*mut PROJ_NETWORK_HANDLE, ProjError> {
+    let mut retries = 0;
+    let mut url = _string(url)?;
+    // if there's an offset value, read from offset to (offset + length) - 1
+    // - 1 is used because the HTTP convention is to use inclusive start and end offsets
+    let end = offset as usize + size_to_read - 1;
+    // RANGE header definition is "bytes=x-y"
+    let hvalue = format!("bytes={}-{}", offset, end);
+    // Create a new client that can be reused for subsequent queries
+    let clt = Client::builder().build()?;
+    // Store req into the handle so new ranges can be queried
+    let req = clt.request(Method::GET, &url);
+    // this performs the initial byte read, presumably as an error check
+    let initial = req.try_clone().ok_or(ProjError::RequestCloneError)?;
+    let with_headers = initial.header("Range", &hvalue).header("Client", CLIENT);
+    let mut res = with_headers.send()?;
+    let mut status = res.status().as_u16();
+    // If something went wrong, start retrying
+    while status >= 300 && retries <= MAX_RETRIES {
+        retries += 1;
+        let wait = time::Duration::from_millis(get_wait_time_exp(retries as i32));
+        thread::sleep(wait);
+        let mut retry = req.try_clone().ok_or(ProjError::RequestCloneError)?;
+        // If it's 3xx, try to get the location header and set it as the new URL
+        if status >= 300 && status < 400 {
+            url = res
+                .headers()
+                .get("location")
+                .ok_or_else(|| ProjError::HeaderError("location".to_string()))?
+                .to_str()?
+                .to_string();
+            retry = clt.request(Method::GET, &url);
+        }
+        let with_headers = retry.header("Range", &hvalue).header("Client", CLIENT);
+        res = with_headers.send()?;
+        status = res.status().as_u16();
+    }
+    // Retries are exhausted to no avail, so give up with an error
+    if status >= 400 {
+        return Err(ProjError::DownloadError(
+            res.status().as_str().to_string(),
+            url,
+            retries,
+        ));
+    }
+    // Write the initial read length value into the pointer
+    unsafe { out_size_read.write(res.content_length().ok_or(ProjError::ContentLength)? as usize) };
+    let headers = res.headers().clone();
+    let response_bytes = res.bytes()?.into_iter().collect::<Vec<u8>>();
+    let bufferlength = response_bytes.len();
+    // Copy the downloaded bytes into the buffer so it can be passed around
+    unsafe {
+        response_bytes
+            .as_ptr()
+            .copy_to_nonoverlapping(buffer as *mut u8, bufferlength.min(size_to_read))
+    };
+    let hd = HandleData::new(req, headers, None);
+    // heap-allocate the struct and cast it to a void pointer so it can be passed around to PROJ
+    let hd_boxed = Box::new(hd);
+    let void: *mut c_void = Box::into_raw(hd_boxed) as *mut c_void;
+    let opaque: *mut PROJ_NETWORK_HANDLE = void as *mut PROJ_NETWORK_HANDLE;
+    // If everything's OK, set the error string to empty
+    // TODO are you sure there's no internal nul tho
+    let err_string = "";
+    unsafe {
+        out_error_string.copy_from_nonoverlapping(err_string.as_ptr().cast(), err_string.len());
+        out_error_string.add(err_string.len()).write(0);
+    }
+    Ok(opaque)
+}
+
+/// Network callback: close connection and drop handle data (client and headers)
+pub(crate) unsafe extern "C" fn network_close(
+    _: *mut PJ_CONTEXT,
+    handle: *mut PROJ_NETWORK_HANDLE,
+    _: *mut c_void,
+) {
+    // Reconstitute the Handle data so it can be dropped
+    let hd = &*(handle as *const c_void as *mut HandleData);
+    // Reconstitute and drop the header value returned by network_get_header_value,
+    // since PROJ never explicitly returns it to us
+    if let Some(header) = hd.hptr {
+        let _ = CString::from_raw(header as *mut i8);
+    }
+    let _ = *hd;
+}
+
+/// Network callback: get header value
+///
+/// Note that this function is a facade for _network_get_header_value
+pub(crate) unsafe extern "C" fn network_get_header_value(
+    pc: *mut PJ_CONTEXT,
+    handle: *mut PROJ_NETWORK_HANDLE,
+    header_name: *const c_char,
+    ud: *mut c_void,
+) -> *const c_char {
+    let mut hd = &mut *(handle as *const c_void as *mut HandleData);
+    match _network_get_header_value(pc, handle, header_name, ud) {
+        Ok(res) => res,
+        Err(_) => {
+            // an empty value will cause an error upstream in libproj, which is the intention
+            let hvalue = "";
+            // unwrapping an empty str is fine
+            let cstr = CString::new(hvalue).unwrap();
+            let err = cstr.into_raw();
+            hd.hptr = Some(err);
+            err
+        }
+    }
+}
+
+/// Network callback: get header value
+fn _network_get_header_value(
+    _: *mut PJ_CONTEXT,
+    handle: *mut PROJ_NETWORK_HANDLE,
+    header_name: *const c_char,
+    _: *mut c_void,
+) -> Result<*const c_char, ProjError> {
+    let lookup = _string(header_name)?.to_lowercase();
+    let mut hd = unsafe { &mut *(handle as *mut c_void as *mut HandleData) };
+    let hvalue = hd
+        .headers
+        .get(&lookup)
+        .ok_or_else(|| ProjError::HeaderError(lookup.to_string()))?
+        .to_str()?;
+    let cstr = CString::new(hvalue).unwrap();
+    let header = cstr.into_raw();
+    hd.hptr = Some(header);
+    Ok(header)
+}
+/// Network: read range
+///
+/// Read size_to_read bytes from handle, starting at `offset`, into `buffer`. During this read,
+/// the implementation should make sure to store the HTTP headers from the server response to be
+/// able to respond to `proj_network_get_header_value_cbk_type` callback.
+/// `error_string_max_size` should be the maximum size that can be written into the
+/// `out_error_string` buffer (including terminating nul character).
+///
+/// Return value should be the actual number of bytes read, 0 in case of error.
+///
+/// Note that this function is a facade for _network_read_range
+pub(crate) unsafe extern "C" fn network_read_range(
+    pc: *mut PJ_CONTEXT,
+    handle: *mut PROJ_NETWORK_HANDLE,
+    offset: c_ulonglong,
+    size_to_read: usize,
+    buffer: *mut c_void,
+    error_string_max_size: usize,
+    out_error_string: *mut c_char,
+    ud: *mut c_void,
+) -> usize {
+    match _network_read_range(
+        pc,
+        handle,
+        offset,
+        size_to_read,
+        buffer,
+        error_string_max_size,
+        out_error_string,
+        ud,
+    ) {
+        Ok(res) => res,
+        Err(e) => {
+            // I assume that if 0 is returned, whatever error is in out_error_string is displayed by libproj
+            let err_string = e.to_string();
+            out_error_string.copy_from_nonoverlapping(err_string.as_ptr().cast(), err_string.len());
+            out_error_string.add(err_string.len()).write(0);
+            0usize
+        }
+    }
+}
+
+/// Where the ACTUAL work happens
+fn _network_read_range(
+    _: *mut PJ_CONTEXT,
+    handle: *mut PROJ_NETWORK_HANDLE,
+    offset: c_ulonglong,
+    size_to_read: usize,
+    buffer: *mut c_void,
+    _: usize,
+    out_error_string: *mut c_char,
+    _: *mut c_void,
+) -> Result<usize, ProjError> {
+    // if there's an offset value, read from offset to (offset + length) - 1
+    // - 1 is used because the HTTP convention is to use inclusive start and end offsets
+    let end = offset as usize + size_to_read - 1;
+    let mut retries = 0;
+    let hvalue = format!("bytes={}-{}", offset, end);
+    let mut hd = unsafe { &mut *(handle as *const c_void as *mut HandleData) };
+    let initial = hd.client.try_clone().ok_or(ProjError::RequestCloneError)?;
+    let with_headers = initial.header("Range", &hvalue).header("Client", CLIENT);
+    let mut res = with_headers.send()?;
+    let mut status = res.status().as_u16();
+    // If something went wrong, start retrying
+    // 3xx handling isn't required here, because range_read follows network_open
+    // so if network_open got 3xx, the URL has already been modified
+    while status >= 400 && retries <= MAX_RETRIES {
+        retries += 1;
+        let wait = time::Duration::from_millis(get_wait_time_exp(retries as i32));
+        thread::sleep(wait);
+        let retry = hd.client.try_clone().ok_or(ProjError::RequestCloneError)?;
+        let with_headers = retry.header("Range", &hvalue).header("Client", CLIENT);
+        res = with_headers.send()?;
+        status = res.status().as_u16();
+    }
+    // Retries are exhausted to no avail, so give up with an error
+    if status >= 400 {
+        return Err(ProjError::DownloadError(
+            res.status().as_str().to_string(),
+            res.url().to_string(),
+            retries,
+        ));
+    }
+    let headers = res.headers().clone();
+    let response_bytes = res.bytes()?.into_iter().collect::<Vec<u8>>();
+    let bufferlength = response_bytes.len();
+    // Copy the downloaded bytes into the buffer so it can be passed around
+    unsafe {
+        response_bytes
+            .as_ptr()
+            .copy_to_nonoverlapping(buffer as *mut u8, bufferlength.min(size_to_read));
+    }
+    let err_string = "";
+    // TODO are you sure there's no internal nul tho
+    unsafe {
+        out_error_string.copy_from_nonoverlapping(err_string.as_ptr().cast(), err_string.len());
+        out_error_string.add(err_string.len()).write(0);
+    }
+    hd.headers = headers;
+    Ok(bufferlength)
+}
+
+/// Set up and initialise the grid download callback functions for this and all subsequent PROJ contexts
+pub(crate) fn set_network_callbacks(ctx: *mut PJ_CONTEXT) -> i32 {
+    let ud: *mut c_void = ptr::null_mut();
+    let dctx: *mut PJ_CONTEXT = ptr::null_mut();
+    unsafe {
+        proj_context_set_network_callbacks(
+            ctx,
+            Some(network_open),
+            Some(network_close),
+            Some(network_get_header_value),
+            Some(network_read_range),
+            ud,
+        );
+        proj_context_set_network_callbacks(
+            dctx,
+            Some(network_open),
+            Some(network_close),
+            Some(network_get_header_value),
+            Some(network_read_range),
+            ud,
+        )
+    }
+}

--- a/src/network.rs
+++ b/src/network.rs
@@ -61,7 +61,7 @@ fn get_wait_time_exp(retrycount: i32) -> u64 {
     (retrycount as u64).pow(2) * 100u64
 }
 
-/// Process CDN response: handle retries in case of server error, or early return in for client errors
+/// Process CDN response: handle retries in case of server error, or early return for client errors
 fn error_handler<'a>(
     res: &'a mut Response,
     rb: RequestBuilder,

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -107,7 +107,7 @@ fn area_set_bbox(parea: *mut proj_sys::PJ_AREA, new_area: Option<Area>) {
     }
 }
 
-/// called by Proj::new and TransformBuilder::transform_new_crs
+/// called by Proj::new and ProjBuilder::transform_new_crs
 fn transform_string(ctx: *mut PJ_CONTEXT, definition: &str) -> Option<Proj> {
     let c_definition = CString::new(definition).ok()?;
     let new_c_proj = unsafe { proj_create(ctx, c_definition.as_ptr()) };
@@ -190,14 +190,14 @@ pub trait Info {
     }
 }
 
-impl Info for TransformBuilder {
+impl Info for ProjBuilder {
     #[doc(hidden)]
     fn ctx(&self) -> *mut PJ_CONTEXT {
         self.ctx
     }
 }
 
-impl TransformBuilder {
+impl ProjBuilder {
     /// Enable or disable network access for [resource file download](https://proj.org/resource_files.html#where-are-proj-resource-files-looked-for).
     ///
     /// # Safety
@@ -301,15 +301,15 @@ pub struct Projinfo {
 /// A `PROJ` Context instance, used to create a transformation object.
 ///
 /// Create a transformation object by calling `transform_new` or `transform_known_crs`.
-pub struct TransformBuilder {
+pub struct ProjBuilder {
     ctx: *mut PJ_CONTEXT,
 }
 
-impl TransformBuilder {
-    /// Create a new `TransformBuilder`, allowing grid downloads and other customisation.
+impl ProjBuilder {
+    /// Create a new `ProjBuilder`, allowing grid downloads and other customisation.
     pub fn new() -> Self {
         let ctx = unsafe { proj_context_create() };
-        TransformBuilder { ctx }
+        ProjBuilder { ctx }
     }
 
     /// Try to create a coordinate transformation object
@@ -375,7 +375,7 @@ impl TransformBuilder {
     }
 }
 
-impl Default for TransformBuilder {
+impl Default for ProjBuilder {
     fn default() -> Self {
         Self::new()
     }
@@ -759,7 +759,7 @@ impl Drop for Proj {
     }
 }
 
-impl Drop for TransformBuilder {
+impl Drop for ProjBuilder {
     fn drop(&mut self) {
         unsafe {
             proj_context_destroy(self.ctx);
@@ -780,8 +780,8 @@ mod test {
     #[test]
     // This test should be disabled by default, as it requires network access
     fn test_network_enabled_conversion() {
-        let tf = TransformBuilder::new();
-        let tf2 = TransformBuilder::new();
+        let tf = ProjBuilder::new();
+        let tf2 = ProjBuilder::new();
         // OSGB 1936
         let from = "EPSG:4277";
         // ETRS89
@@ -819,7 +819,7 @@ mod test {
     #[should_panic]
     // This failure is a bug in libproj
     fn test_searchpath() {
-        let tf = TransformBuilder::new();
+        let tf = ProjBuilder::new();
         tf.set_search_paths(&"/foo").unwrap();
         let ipath = tf.info().unwrap().searchpath;
         let pathsep = if cfg!(windows) { ";" } else { ":" };
@@ -830,7 +830,7 @@ mod test {
     fn test_set_endpoint() {
         let from = "EPSG:4326";
         let to = "EPSG:4326+3855";
-        let tf = TransformBuilder::new();
+        let tf = ProjBuilder::new();
         let ep = tf.get_url_endpoint().unwrap();
         assert_eq!(&ep, "https://cdn.proj.org");
         tf.set_url_endpoint("https://github.com/georust").unwrap();

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -323,7 +323,7 @@ impl TransformBuilder {
     ///
     /// # Safety
     /// This method contains unsafe code.
-    pub fn transform(mut self, definition: &str) -> Option<Proj> {
+    pub fn proj(mut self, definition: &str) -> Option<Proj> {
         let ctx = unsafe { std::mem::replace(&mut self.ctx, proj_context_create()) };
         Some(transform_string(ctx, definition)?)
     }

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -122,7 +122,7 @@ fn transform_string(ctx: *mut PJ_CONTEXT, definition: &str) -> Option<Proj> {
     }
 }
 
-/// Called by new_known_crs and transform_known_crs
+/// Called by new_known_crs and proj_known_crs
 fn transform_epsg(ctx: *mut PJ_CONTEXT, from: &str, to: &str, area: Option<Area>) -> Option<Proj> {
     let from_c = CString::new(from).ok()?;
     let to_c = CString::new(to).ok()?;
@@ -300,7 +300,7 @@ pub struct Projinfo {
 
 /// A `PROJ` Context instance, used to create a transformation object.
 ///
-/// Create a transformation object by calling `transform_new` or `transform_known_crs`.
+/// Create a transformation object by calling `proj` or `proj_known_crs`.
 pub struct ProjBuilder {
     ctx: *mut PJ_CONTEXT,
 }
@@ -369,7 +369,7 @@ impl ProjBuilder {
     ///
     /// # Safety
     /// This method contains unsafe code.
-    pub fn transform_known_crs(mut self, from: &str, to: &str, area: Option<Area>) -> Option<Proj> {
+    pub fn proj_known_crs(mut self, from: &str, to: &str, area: Option<Area>) -> Option<Proj> {
         let ctx = unsafe { std::mem::replace(&mut self.ctx, proj_context_create()) };
         Some(transform_epsg(ctx, from, to, area)?)
     }
@@ -794,8 +794,8 @@ mod test {
         tf.enable_network(true).unwrap();
         assert_eq!(tf.network_enabled(), true);
         // I expected the following call to trigger a download, but it doesn't!
-        let proj = tf.transform_known_crs(&from, &to, None).unwrap();
-        let proj2 = tf2.transform_known_crs(&from, &to, None).unwrap();
+        let proj = tf.proj_known_crs(&from, &to, None).unwrap();
+        let proj2 = tf2.proj_known_crs(&from, &to, None).unwrap();
         // download begins here:
         let t = proj.convert(Point::new(0.001653, 52.267733)).unwrap();
         let t2 = proj2.convert(Point::new(0.001653, 52.267733)).unwrap();
@@ -835,7 +835,7 @@ mod test {
         let ep = tf.get_url_endpoint().unwrap();
         assert_eq!(&ep, "https://cdn.proj.org");
         tf.set_url_endpoint("https://github.com/georust").unwrap();
-        let proj = tf.transform_known_crs(&from, &to, None).unwrap();
+        let proj = tf.proj_known_crs(&from, &to, None).unwrap();
         let ep = proj.get_url_endpoint().unwrap();
         // Has the new endpoint propagated to the Proj instance?
         assert_eq!(&ep, "https://github.com/georust");

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -763,6 +763,7 @@ impl Drop for ProjBuilder {
     fn drop(&mut self) {
         unsafe {
             proj_context_destroy(self.ctx);
+            proj_cleanup()
         }
     }
 }

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -698,18 +698,38 @@ mod test {
         assert_almost_eq(t.y(), 1141263.01);
     }
     // This test is disabled by default as it requires network access
+    #[test]
+    fn test_network() {
+        let from = "EPSG:4326";
+        let to = "EPSG:4326+3855";
+        let proj = Proj::new_known_crs(&from, &to, None).unwrap();
+        assert_eq!(proj.network_enabled(), false);
+        // Network download is off by default
+        // switch on cache and enable network
+        proj.grid_cache_enable(true);
+        proj.enable_network(true).unwrap();
+        assert_eq!(proj.network_enabled(), true);
+
+        let t = proj.convert(Point::new(40.0, -80.0)).unwrap();
+        assert_almost_eq(t.x(), 39.99999839);
+        assert_almost_eq(t.y(), -79.99999807);
+    }
     // #[test]
-    // fn test_network() {
+    // fn flibble() {
+    //     let mut tf = TransformBuilder::new();
+    //     // off by default
+    //     assert_eq!(tf.network_enabled(), false);
+    //     tf.grid_cache_enable(true);
+    //     tf.enable_network(true).unwrap();
+    //     assert_eq!(tf.network_enabled(), true);
     //     let from = "EPSG:4326";
     //     let to = "EPSG:4326+3855";
-    //     // off by default
-    //     assert_eq!(network_enabled(), false);
-    //     // switch it on and disable cache for subsequent calls
-    //     grid_cache_set_enable(false);
-    //     enable_network(true).unwrap();
-    //     let proj = Proj::new_known_crs(&from, &to, None).unwrap();
-    //     assert_eq!(network_enabled(), true);
+    //     // This should trigger a download???
+    //     let proj = tf.transform_known_crs(&from, &to, None).unwrap();
+    //     println!("{:?}", "yo");
+    //     // Download begins here???
     //     let t = proj.convert(Point::new(40.0, -80.0)).unwrap();
+    //     println!("{:?}", "done");
     //     assert_almost_eq(t.x(), 39.99999839);
     //     assert_almost_eq(t.y(), -79.99999807);
     // }


### PR DESCRIPTION
Uses `reqwest` and the network callback functionality provided by `libproj`.