### PR TITLE
disable default features, like openssl, since we're using rust-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ geo-types ="0.6.0"
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"
-reqwest = { version = "0.10.6", features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.10.6", features = ["blocking", "rustls-tls"], default-features = false }
 
 [features]
 bundled_proj = [ "proj-sys/bundled_proj" ]


### PR DESCRIPTION
I'm still testing this locally, but wanted to make sure you saw it @urschrei to avoid duplicated efforts.