### PR TITLE
Remove default features from reqwest

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 0.20.3
+* Disable default features in Reqwest
+
 ## 0.20.0
 * Add network control and grid download functionality
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.20.1"
+version = "0.20.2"
 authors = [
     "The Georust Developers <mods@georust.org>"
 ]
@@ -13,7 +13,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-proj-sys = "0.18.0"
+proj-sys = "0.18.1"
 geo-types ="0.6.0"
 libc = "0.2.62"
 num-traits = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.20.2"
+version = "0.20.3"
 authors = [
     "The Georust Developers <mods@georust.org>"
 ]
@@ -18,7 +18,7 @@ geo-types ="0.6.0"
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"
-reqwest = { version = "0.10.6", features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.10.6", default-features= false, features = ["blocking", "rustls-tls"] }
 
 [features]
 bundled_proj = [ "proj-sys/bundled_proj" ]

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -776,10 +776,9 @@ mod test {
     fn assert_almost_eq(a: f64, b: f64) {
         let f: f64 = a / b;
         assert!(f < 1.00001);
-        assert!(f > 0.99999);
+        assert!(f > 0.99999);    // This test should be disabled by default, as it requires network access
     }
     // #[test]
-    // // This test should be disabled by default, as it requires network access
     // fn test_network_enabled_conversion() {
     //     let tf = ProjBuilder::new();
     //     let tf2 = ProjBuilder::new();

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -799,7 +799,7 @@ mod test {
     //     // download begins here:
     //     let t = proj.convert(Point::new(0.001653, 52.267733)).unwrap();
     //     let t2 = proj2.convert(Point::new(0.001653, 52.267733)).unwrap();
-        
+
     //     // High-quality OSTN15 conversion
     //     assert_almost_eq(t.x(), 0.000026091248979289044);
     //     assert_almost_eq(t.y(), 52.26817146070213);


### PR DESCRIPTION
These include dependencies which require OpenSSL, which we wish to avoid.