### PR TITLE
proj w/o geo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,10 @@ jobs:
           - "--features network"
           - "--features bundled_proj"
           - "--features geo-types"
-          - "--features \"network bundled_proj\"", 
-          - "--features \"network geo-types\"", 
-          - "--features \"bundled_proj geo-types\"", 
-          - "--features \"network bundled_proj geo-types\"", 
+          - "--features \"network bundled_proj\""
+          - "--features \"network geo-types\""
+          - "--features \"bundled_proj geo-types\""
+          - "--features \"network bundled_proj geo-types\""
     container:
       image: georust/proj-ci:latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features: ["", "--features network", "--features bundled_proj", "--features \"bundled_proj network\""]
+        features: 
+          - ""
+          - "--features network"
+          - "--features bundled_proj"
+          - "--features geo-types"
+          - "--features \"network bundled_proj\"", 
+          - "--features \"network geo-types\"", 
+          - "--features \"bundled_proj geo-types\"", 
+          - "--features \"network bundled_proj geo-types\"", 
     container:
       image: georust/proj-ci:latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 
 [dependencies]
 proj-sys = { version = "0.18.3", path = "proj-sys" }
+geo-types = { version = "0.6", optional = true }
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 
 [dependencies]
 proj-sys = { version = "0.18.3", path = "proj-sys" }
-geo-types ="0.6.0"
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,5 @@ network = ["reqwest"]
 assert_approx_eq = "1.1.0"
 
 [package.metadata.docs.rs]
-features = [ "proj-sys/nobuild", "network" ]
+features = [ "proj-sys/nobuild", "network", "geo-types" ]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ projected coordinate systems. The PROJ [documentation](https://proj.org/operatio
 explains the distinction between these operations in more detail.
 
 This crate depends on [`libproj v7.1.x`](https://proj.org), accessed via the
-[`proj-sys`](proj-sys) crate. By default, `proj-sys` will try to find a pre-existing
-installation of libproj on your system. If an appropriate version of libproj cannot be found,
-the build script will attempt to build `libproj` from source. You may specify a from-source
-build with the [`bundled_proj` feature](#feature-flags).
+[`proj-sys`](https://docs.rs/proj-sys) crate. By default, `proj-sys` will try to find a
+pre-existing installation of libproj on your system. If an appropriate version of libproj
+cannot be found, the build script will attempt to build libproj from source. You may specify a
+from-source build with the [`bundled_proj` feature](#feature-flags).
 
 Out of the box, any `(x, y)` numeric tuple can be provided as input to proj. You can [conform
 your own types](#conform-your-own-types) to the [Coord](proj/trait.Coord.html) trait to pass

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ assert_approx_eq!(result.x(), 158458.67251293268);
 assert_approx_eq!(result.y(), -434296.8803996085);
 ```
 
-## Integration with `geo-types`
+### Integration with `geo-types`
 
 If you've enabled the `geo-types` feature, you can skip allocating an intermediate representation,
 and pass the [`geo-types`](https://crates.io/crates/geo-types) directly.
@@ -209,8 +209,8 @@ let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 
 let result = nad_ft_to_m.convert(my_point).unwrap();
 
-assert_approx_eq!(result.x(), 1450880.29f64);
-assert_approx_eq!(result.y(), 1141263.01f64);
+assert_approx_eq!(result.x(), 1450880.2910605003f64);
+assert_approx_eq!(result.y(), 1141263.0111604529f64);
 ```
 
 License: MIT/Apache-2.0

--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ By default, this crate depends on a pre-built `libproj`, accessed by the [`proj-
 
 ## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using EPSG Codes
 ```rust
-use proj::Proj;
-
-extern crate geo_types;
-use geo_types::Point;
+use proj::{Proj, Point};
 
 let from = "EPSG:2230";
 let to = "EPSG:26946";
@@ -47,10 +44,7 @@ Note that as of v5.0.0, PROJ uses the [`pipeline`](https://proj.org/operations/p
 
 ## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using the `pipeline` Operator
 ```rust
-use proj::Proj;
-
-extern crate geo_types;
-use geo_types::Point;
+use proj::{Proj, Point};
 
 let ft_to_m = Proj::new("
     +proj=pipeline
@@ -70,10 +64,7 @@ assert_eq!(result.y(), 1141263.01);
 
 ## Inverse Projection from [Stereo70](https://epsg.io/3844) to Geodetic
 ```rust
-use proj::Proj;
-
-extern crate geo_types;
-use geo_types::Point;
+use proj::{Proj, Point};
 
 // Carry out an inverse projection from Pulkovo 1942(58) / Stereo70 (EPSG 3844)
 // into geodetic lon and lat coordinates (in radians)

--- a/README.md
+++ b/README.md
@@ -1,50 +1,62 @@
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/georust/proj/proj%20ci)
+-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/georust/proj/proj%20ci)
 
 # PROJ
 
-High-level Rust bindings for the latest stable version of [PROJ](https://github.com/OSGeo/proj) (7.1.x), compatible with the [Georust](https://crates.io/geo) ecosystem. Includes network grid download functionality.
+Coordinate transformation via bindings to the [PROJ](https://proj.org) v7.1.x API.
 
-# Requirements
+Two coordinate transformation operations are currently provided: _projection_ (and inverse
+projection) and _conversion_.
 
-By default, this crate depends on a pre-built `libproj`, accessed by the [`proj-sys`](proj-sys) crate: if PROJ v7.1.x is present on your system and can be located by the build script, it will be used. As a fallback, `libproj` will be built from source. While this crate may be backwards-compatible with older PROJ 7 and PROJ 6 versions, this is neither tested nor supported.
+_Projection_ is intended for transformations between geodetic and projected coordinates and
+vice versa (inverse projection), while _conversion_ is intended for transformations between
+projected coordinate systems. The PROJ [documentation](https://proj.org/operations/index.html)
+explains the distinction between these operations in more detail.
 
-## Feature Flags
+This crate depends on [`libproj v7.1.x`](https://proj.org), accessed via the
+[`proj-sys`](proj-sys) crate. By default, `proj-sys` will try to find a pre-existing
+installation of libproj on your system. If an appropriate version of libproj cannot be found,
+the build script will attempt to build `libproj` from source. You may specify a from-source
+build with the [`bundled_proj` feature](#feature-flags).
 
-- `pkg_config`: enables the use of `pkg-config` when linking against `libproj` —
-  note that `pkg-config` must be available on your system. This feature and `bundled_proj` are mutually exclusive.
-- `bundled_proj`: builds `libproj` from source bundled in the `proj-sys` crate.
-  Note that this feature requires Sqlite3 and `libtiff` to be present on your
-  system. This feature and `bundled_proj` are mutually exclusive.
-- `network`: exposes APIs which, when enabled, can fetch grid data from the
-  internet to improve projection accuracy. See
-  [`enable_network`](https://docs.rs/proj/latest/proj/struct.ProjBuilder.html#method.enable_network) for
-  details.
+Out of the box, any `(x, y)` numeric tuple can be provided as input to proj. You can [conform
+your own types](#conform-your-own-types) to the [Coord](proj/trait.Coord.html) trait to pass
+them in directly and avoid intermediate allocations. There is a [`geo-types`
+feature](#feature-flags) to enable such impl's for users of the the [`geo-types`
+crate](https://docs.rs/geo-types).
 
-# Examples
+Methods for [conversion](struct.Proj.html#method.convert_array) and
+[projection](struct.Proj.html#method.project_array) of slices of `Coord`s are also available.
 
-## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using EPSG Codes
+## Examples
+
+### Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using EPSG Codes
+
 ```rust
-use proj::{Proj, Point};
+use proj::Proj;
 
 let from = "EPSG:2230";
 let to = "EPSG:26946";
 let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 let result = ft_to_m
-    .convert(Point::new(4760096.421921, 3744293.729449))
+    .convert((4760096.421921f64, 3744293.729449f64))
     .unwrap();
-assert_approx_eq!(result.x() as f64, 1450880.2910605003);
-assert_approx_eq!(result.y() as f64, 1141263.0111604529);
+assert_approx_eq!(result.0, 1450880.2910605003);
+assert_approx_eq!(result.1, 1141263.0111604529);
 ```
 
-Note that as of v5.0.0, PROJ uses the [`pipeline`](https://proj.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The example below works as follows:
+### Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using the `pipeline` Operator
+
+Note that as of v5.0.0, PROJ uses the [`pipeline`](https://proj.org/operations/pipeline.html)
+operator, which allows an arbitrary number of steps in a conversion. The example below works as
+follows:
 
 - define the operation as a `pipeline` operation
 - define `step` 1 as an `inv`erse transform, yielding geodetic coordinates
 - define `step` 2 as a forward transform to projected coordinates, yielding metres.
 
-## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using the `pipeline` Operator
+
 ```rust
-use proj::{Proj, Point};
+use proj::Proj;
 
 let ft_to_m = Proj::new("
     +proj=pipeline
@@ -55,16 +67,18 @@ let ft_to_m = Proj::new("
     +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666
     +lon_0=-116.25 +x_0=2000000 +y_0=500000
     +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
-", false).unwrap();
+").unwrap();
+
 // The Presidio, approximately
-let result = ft_to_m.convert(Point::new(4760096.421921, 3744293.729449)).unwrap();
-assert_eq!(result.x(), 1450880.29);
-assert_eq!(result.y(), 1141263.01);
+let result = ft_to_m.convert((4760096.421921f64, 3744293.729449f64)).unwrap();
+assert_approx_eq!(result.0, 1450880.2910605003);
+assert_approx_eq!(result.1, 1141263.01116045);
 ```
 
-## Inverse Projection from [Stereo70](https://epsg.io/3844) to Geodetic
+### Inverse Projection from [Stereo70](https://epsg.io/3844) to Geodetic
+
 ```rust
-use proj::{Proj, Point};
+use proj::Proj;
 
 // Carry out an inverse projection from Pulkovo 1942(58) / Stereo70 (EPSG 3844)
 // into geodetic lon and lat coordinates (in radians)
@@ -73,20 +87,130 @@ let stereo70 = Proj::new("
     +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84
     +units=m +no_defs
     ").unwrap();
-let rp = stereo70.project(
-    Point::new(500119.70352012233, 500027.77896348457), true
+let geodetic_radians_point = stereo70.project(
+    (500119.70352012233f64, 500027.77896348457f64), true
 ).unwrap();
-assert_eq!(rp, Point::new(0.436332, 0.802851));
+assert_approx_eq!(geodetic_radians_point.0, 0.436332);
+assert_approx_eq!(geodetic_radians_point.1, 0.802851);
 ```
 
-## Bulk Transformations
-The `Proj::convert_array()` and `Proj::project_array()`methods are available for bulk conversions. Both accept mutable slices (or anything that can `Deref` to a mutable slice) of `Point<T: Float>` or `Into<Point<T: Float>` elements.
+## Usage
 
-# License
+There are two options for creating a transformation:
 
-Licensed under either of
+1. If you don't require additional [grids](#grid-file-download) or other customisation:
+    - Call `Proj::new` or `Proj::new_known_crs`. This creates a transformation instance ([`Proj`](proj/struct.Proj.html))
+2. If you require a grid for the transformation you wish to carry out, or you need to customise
+   the search path or the grid endpoint:
+   - Create a new [`ProjBuilder`](proj/struct.ProjBuilder.html) by calling
+     `ProjBuilder::new()`. It may be modified to enable network downloads, disable the grid,
+     cache or modify search paths;
+   - Call [`ProjBuilder.proj()`](proj/struct.ProjBuilder.html#method.proj) or
+     [`ProjBuilder.proj_known_crs()`](proj/struct.ProjBuilder.html#method.proj_known_crs). This
+     creates a transformation instance (`Proj`)
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+**Note**:
 
-at your option.
+1. Both `ProjBuilder` and `Proj` implement the [`Info`](proj/trait.Info.html) trait, which can
+   be used to get information about the current state of the `PROJ` instance;
+2. `Proj::new()` and `ProjBuilder::proj()` have the same signature;
+3. `Proj::new_known_crs()` and `ProjBuilder::proj_known_crs()` have the same signature.
+
+## Requirements
+
+By default, the crate requires `libproj` 7.1.x to be present on your system. While it may be
+backwards-compatible with older PROJ 6 versions, this is neither tested nor supported.
+
+## Feature Flags
+
+- `geo-types`: include [trait impls for
+  `geo-types`](proj/trait.Coord.html#impl-Coord%3CT%3E-for-Coordinate%3CT%3E). See
+  [example](#integration-with-geo-types).
+- `pkg_config`: enables the use of `pkg-config` when linking against `libproj` —
+  note that `pkg-config` must be available on your system.
+- `bundled_proj`: builds `libproj` from source bundled in the `proj-sys` crate.
+  Note that this feature requires Sqlite3 and `libtiff` to be present on your
+  system.
+- `network`: exposes APIs which, when enabled, can fetch grid data from the internet to improve
+  projection accuracy. See [`enable_network`](struct.ProjBuilder.html#method.enable_network)
+  for details.
+
+### Network, Cache, and Search Path Functionality
+
+#### Grid File Download
+
+`proj` supports [network grid download](https://proj.org/usage/network.html) functionality via
+the [`network` feature](#feature-flags).  Network access is **disabled** by default, and can be
+activated by passing a `true` `bool` to
+[`enable_network()`](proj/struct.ProjBuilder.html#method.enable_network).  Network
+functionality status can be queried with `network_enabled`, and the download endpoint can be
+queried and set using `get_url_endpoint` and `set_url_endpoint`.
+
+##### Grid File Cache
+Up to 300 mb of downloaded grids are cached to save bandwidth: This cache can be enabled or
+disabled using [`grid_cache_enable`](proj/struct.ProjBuilder.html#method.grid_cache_enable).
+
+#### Search Path Modification
+The path used to search for resource files can be modified using
+[`set_search_paths`](proj/struct.ProjBuilder.html#method.set_search_paths)
+
+### Conform your own types
+
+If you have your own geometric types, you can conform them to the `Coord` trait and use `proj`
+without any intermediate allocation.
+
+```rust
+use proj::{Proj, Coord};
+
+struct MyPointOfIntereset {
+    lat: f64,
+    lon: f64,
+}
+
+impl Coord<f64> for MyPointOfIntereset {
+    fn x(&self) -> f64 {
+        self.lon
+    }
+    fn y(&self) -> f64 {
+        self.lat
+    }
+    fn from_xy(x: f64, y: f64) -> Self {
+        Self { lon: x, lat: y }
+    }
+}
+
+let donut_shop = MyPointOfIntereset { lat: 34.095620, lon: -118.283555 };
+
+let from = "EPSG:4326";
+let to = "EPSG:3309";
+let proj = Proj::new_known_crs(&from, &to, None).unwrap();
+
+let result = proj.convert(donut_shop).unwrap();
+
+assert_approx_eq!(result.x(), 158458.67251293268);
+assert_approx_eq!(result.y(), -434296.8803996085);
+```
+
+## Integration with `geo-types`
+
+If you've enabled the `geo-types` feature, you can skip allocating an intermediate representation,
+and pass the [`geo-types`](https://crates.io/crates/geo-types) directly.
+
+```rust
+# use assert_approx_eq::assert_approx_eq;
+use proj::Proj;
+use geo_types::Point;
+
+let my_point = Point::new(4760096.421921f64, 3744293.729449f64);
+
+let from = "EPSG:2230";
+let to = "EPSG:26946";
+let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+
+let result = nad_ft_to_m.convert(my_point).unwrap();
+
+assert_approx_eq!(result.x(), 1450880.29f64);
+assert_approx_eq!(result.y(), 1141263.01f64);
+```
+
+License: MIT/Apache-2.0

--- a/src/geo_types.rs
+++ b/src/geo_types.rs
@@ -1,0 +1,53 @@
+///```rust
+/// # use assert_approx_eq::assert_approx_eq;
+/// extern crate proj;
+/// use proj::Proj;
+/// use geo_types::Coordinate;
+///
+/// let from = "EPSG:2230";
+/// let to = "EPSG:26946";
+/// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+/// let result = nad_ft_to_m
+///     .convert(Coordinate { x: 4760096.421921f64, y: 3744293.729449f64 })
+///     .unwrap();
+/// assert_approx_eq!(result.x, 1450880.29f64, 1.0e-2);
+/// assert_approx_eq!(result.y, 1141263.01f64, 1.0e-2);
+/// ```
+impl<T: crate::proj::CoordinateType> crate::Point<T> for geo_types::Coordinate<T> {
+    fn x(&self) -> T {
+        self.x
+    }
+    fn y(&self) -> T {
+        self.y
+    }
+    fn from_xy(x: T, y: T) -> Self {
+        Self { x, y }
+    }
+}
+
+///```rust
+/// # use assert_approx_eq::assert_approx_eq;
+/// extern crate proj;
+/// use proj::Proj;
+/// use geo_types::Point;
+///
+/// let from = "EPSG:2230";
+/// let to = "EPSG:26946";
+/// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+/// let result = nad_ft_to_m
+///     .convert(Point::new(4760096.421921f64, 3744293.729449f64))
+///     .unwrap();
+/// assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
+/// assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
+/// ```
+impl<T: crate::proj::CoordinateType> crate::Point<T> for geo_types::Point<T> {
+    fn x(&self) -> T {
+        geo_types::Point::x(*self)
+    }
+    fn y(&self) -> T {
+        geo_types::Point::y(*self)
+    }
+    fn from_xy(x: T, y: T) -> Self {
+        Self::new(x, y)
+    }
+}

--- a/src/geo_types.rs
+++ b/src/geo_types.rs
@@ -13,7 +13,7 @@
 /// assert_approx_eq!(result.x, 1450880.29f64, 1.0e-2);
 /// assert_approx_eq!(result.y, 1141263.01f64, 1.0e-2);
 /// ```
-impl<T: crate::proj::CoordinateType> crate::Point<T> for geo_types::Coordinate<T> {
+impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Coordinate<T> {
     fn x(&self) -> T {
         self.x
     }
@@ -40,7 +40,7 @@ impl<T: crate::proj::CoordinateType> crate::Point<T> for geo_types::Coordinate<T
 /// assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
 /// assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
 /// ```
-impl<T: crate::proj::CoordinateType> crate::Point<T> for geo_types::Point<T> {
+impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Point<T> {
     fn x(&self) -> T {
         geo_types::Point::x(*self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@
 //! explains the distinction between these operations in more detail.
 //!
 //! This crate depends on [`libproj v7.1.x`](https://proj.org), accessed via the
-//! [`proj-sys`](proj-sys) crate. By default, `proj-sys` will try to find a pre-existing
-//! installation of libproj on your system. If an appropriate version of libproj cannot be found,
-//! the build script will attempt to build `libproj` from source. You may specify a from-source
-//! build with the [`bundled_proj` feature](#feature-flags).
+//! [`proj-sys`](https://docs.rs/proj-sys) crate. By default, `proj-sys` will try to find a
+//! pre-existing installation of libproj on your system. If an appropriate version of libproj
+//! cannot be found, the build script will attempt to build libproj from source. You may specify a
+//! from-source build with the [`bundled_proj` feature](#feature-flags).
 //!
 //! Out of the box, any `(x, y)` numeric tuple can be provided as input to proj. You can [conform
 //! your own types](#conform-your-own-types) to the [Coord](proj/trait.Coord.html) trait to pass

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,11 @@
 
 #[cfg(feature = "network")]
 mod network;
+
+#[cfg_attr(docsrs, feature(doc_cfg))]
+#[cfg(feature = "geo-types")]
+mod geo_types;
+
 mod proj;
 
 pub use crate::proj::Area;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,19 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
-//! Provides coordinate transformation via bindings to the [PROJ](https://proj.org) v7.1.x API.
+//! Coordinate transformation via bindings to the [PROJ](https://proj.org) v7.1.x API.
 //!
-//! Two coordinate transformation operations are currently provided: _projection_
-//! (and inverse projection) and _conversion_.
+//! Two coordinate transformation operations are currently provided: _projection_ (and inverse
+//! projection) and _conversion_.
 //!
-//! Projection is intended for transformations between geodetic and projected coordinates
-//! and vice versa (inverse projection), while conversion is intended for transformations between projected
-//! coordinate systems. The PROJ [documentation](https://proj.org/operations/index.html)
+//! _Projection_ is intended for transformations between geodetic and projected coordinates and
+//! vice versa (inverse projection), while _conversion_ is intended for transformations between
+//! projected coordinate systems. The PROJ [documentation](https://proj.org/operations/index.html)
 //! explains the distinction between these operations in more detail.
+//!
+//! This crate depends on [`libproj v7.1.x`](https://proj.org), accessed via the
+//! [`proj-sys`](proj-sys) crate. By default, `proj-sys` will try to find a pre-existing
+//! installation of libproj on your system. If an appropriate version of libproj cannot be found,
+//! the build script will attempt to build `libproj` from source. You may specify a from-source
+//! build with the [`bundled_proj` feature](#feature-flags).
 //!
 //! Out of the box, any `(x, y)` numeric tuple can be provided as input to proj. You can [conform
 //! your own types](#conform-your-own-types) to the [Coord](proj/trait.Coord.html) trait to pass
@@ -18,51 +24,107 @@
 //! Methods for [conversion](struct.Proj.html#method.convert_array) and
 //! [projection](struct.Proj.html#method.project_array) of slices of `Coord`s are also available.
 //!
+//! # Examples
+//!
+//! ## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using EPSG Codes
+//!
+//! ```rust
+//! # use assert_approx_eq::assert_approx_eq;
+//! use proj::Proj;
+//!
+//! let from = "EPSG:2230";
+//! let to = "EPSG:26946";
+//! let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+//! let result = ft_to_m
+//!     .convert((4760096.421921f64, 3744293.729449f64))
+//!     .unwrap();
+//! assert_approx_eq!(result.0, 1450880.2910605003);
+//! assert_approx_eq!(result.1, 1141263.0111604529);
+//! ```
+//!
+//! ## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using the `pipeline` Operator
+//!
+//! Note that as of v5.0.0, PROJ uses the [`pipeline`](https://proj.org/operations/pipeline.html)
+//! operator, which allows an arbitrary number of steps in a conversion. The example below works as
+//! follows:
+//!
+//! - define the operation as a `pipeline` operation
+//! - define `step` 1 as an `inv`erse transform, yielding geodetic coordinates
+//! - define `step` 2 as a forward transform to projected coordinates, yielding metres.
+//!
+//!
+//! ```rust
+//! # use assert_approx_eq::assert_approx_eq;
+//! use proj::Proj;
+//!
+//! let ft_to_m = Proj::new("
+//!     +proj=pipeline
+//!     +step +inv +proj=lcc +lat_1=33.88333333333333
+//!     +lat_2=32.78333333333333 +lat_0=32.16666666666666
+//!     +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80
+//!     +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs
+//!     +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666
+//!     +lon_0=-116.25 +x_0=2000000 +y_0=500000
+//!     +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+//! ").unwrap();
+//!
+//! // The Presidio, approximately
+//! let result = ft_to_m.convert((4760096.421921f64, 3744293.729449f64)).unwrap();
+//! assert_approx_eq!(result.0, 1450880.2910605003);
+//! assert_approx_eq!(result.1, 1141263.01116045);
+//! ```
+//!
+//! ## Inverse Projection from [Stereo70](https://epsg.io/3844) to Geodetic
+//!
+//! ```rust
+//! # use assert_approx_eq::assert_approx_eq;
+//! use proj::Proj;
+//!
+//! // Carry out an inverse projection from Pulkovo 1942(58) / Stereo70 (EPSG 3844)
+//! // into geodetic lon and lat coordinates (in radians)
+//! let stereo70 = Proj::new("
+//!     +proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000
+//!     +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84
+//!     +units=m +no_defs
+//!     ").unwrap();
+//! let geodetic_radians_point = stereo70.project(
+//!     (500119.70352012233f64, 500027.77896348457f64), true
+//! ).unwrap();
+//! assert_approx_eq!(geodetic_radians_point.0, 0.436332);
+//! assert_approx_eq!(geodetic_radians_point.1, 0.802851);
+//! ```
+//!
 //! # Usage
 //!
 //! There are two options for creating a transformation:
 //!
-//! 1. If you don't require additional grids or other customisation:
+//! 1. If you don't require additional [grids](#grid-file-download) or other customisation:
 //!     - Call `Proj::new` or `Proj::new_known_crs`. This creates a transformation instance ([`Proj`](proj/struct.Proj.html))
-//! 2. If you require a grid for the transformation you wish to carry out, or you need to customise the search path or the grid endpoint:
-//!     - Create a new [`ProjBuilder`](proj/struct.ProjBuilder.html) by calling
-//!     `ProjBuilder::new()`. It may be modified to enable network downloads, disable the grid,
-//!     cache or modify search paths; - Call
-//!     [`ProjBuilder.proj()`](proj/struct.ProjBuilder.html#method.proj) or
-//!     [`ProjBuilder.proj_known_crs()`](proj/struct.ProjBuilder.html#method.proj_known_crs). This
-//!     creates a transformation instance (`Proj`)
+//! 2. If you require a grid for the transformation you wish to carry out, or you need to customise
+//!    the search path or the grid endpoint:
+//!    - Create a new [`ProjBuilder`](proj/struct.ProjBuilder.html) by calling
+//!      `ProjBuilder::new()`. It may be modified to enable network downloads, disable the grid,
+//!      cache or modify search paths;
+//!    - Call [`ProjBuilder.proj()`](proj/struct.ProjBuilder.html#method.proj) or
+//!      [`ProjBuilder.proj_known_crs()`](proj/struct.ProjBuilder.html#method.proj_known_crs). This
+//!      creates a transformation instance (`Proj`)
 //!
 //! **Note**:
 //!
-//! 1. Both `ProjBuilder` and `Proj` implement the [`Info`](proj/trait.Info.html) trait, which can be used to get information about the current state of the `PROJ` instance;
+//! 1. Both `ProjBuilder` and `Proj` implement the [`Info`](proj/trait.Info.html) trait, which can
+//!    be used to get information about the current state of the `PROJ` instance;
 //! 2. `Proj::new()` and `ProjBuilder::proj()` have the same signature;
 //! 3. `Proj::new_known_crs()` and `ProjBuilder::proj_known_crs()` have the same signature.
 //!
-//! ## Network, Cache, and Search Path Functionality
-//!
-//! ### Grid File Download
-//! `proj` supports [network grid download](https://proj.org/usage/network.html) functionality via
-//! the [`network` feature](#feature-flags).
-//! Network access is **disabled** by default, and
-//! can be activated by passing a `true` `bool` to [`enable_network()`](proj/struct.ProjBuilder.html#method.enable_network).
-//! Network functionality status can be queried with
-//! `network_enabled`, and the download endpoint can be queried and set using `get_url_endpoint` and `set_url_endpoint`.
-//!
-//! #### Grid File Cache
-//! Up to 300 mb of downloaded grids are cached to save bandwidth: This cache can be enabled or disabled using [`grid_cache_enable`](proj/struct.ProjBuilder.html#method.grid_cache_enable).
-//!
-//! ### Search Path Modification
-//! The path used to search for resource files can be modified using [`set_search_paths`](proj/struct.ProjBuilder.html#method.set_search_paths)
-//!
-//!
 //! # Requirements
 //!
-//! By default, the crate requires `libproj` 7.1.x to be present on your system. While it may be backwards-compatible with older PROJ 6 versions, this is neither tested nor supported.
+//! By default, the crate requires `libproj` 7.1.x to be present on your system. While it may be
+//! backwards-compatible with older PROJ 6 versions, this is neither tested nor supported.
 //!
-//!## Feature Flags
+//! # Feature Flags
 //!
 //! - `geo-types`: include [trait impls for
-//! `geo-types`](proj/trait.Coord.html#impl-Coord%3CT%3E-for-Coordinate%3CT%3E). See
+//!   `geo-types`](proj/trait.Coord.html#impl-Coord%3CT%3E-for-Coordinate%3CT%3E). See
 //!   [example](#integration-with-geo-types).
 //! - `pkg_config`: enables the use of `pkg-config` when linking against `libproj` —
 //!   note that `pkg-config` must be available on your system.
@@ -70,37 +132,34 @@
 //!   Note that this feature requires Sqlite3 and `libtiff` to be present on your
 //!   system.
 //! - `network`: exposes APIs which, when enabled, can fetch grid data from the internet to improve
-//!   projection accuracy. See [`enable_network`](struct.ProjBuilder.html#method.enable_network) for
-//!   details.
+//!   projection accuracy. See [`enable_network`](struct.ProjBuilder.html#method.enable_network)
+//!   for details.
 //!
-//! # Examples
+//! ## Network, Cache, and Search Path Functionality
 //!
-//! Out of the box, `proj` works with numeric `(x, y)` tuples.
+//! ### Grid File Download
 //!
-//! ```
-//! # use assert_approx_eq::assert_approx_eq;
-//! use proj::{Proj, Coord};
+//! `proj` supports [network grid download](https://proj.org/usage/network.html) functionality via
+//! the [`network` feature](#feature-flags).  Network access is **disabled** by default, and can be
+//! activated by passing a `true` `bool` to
+//! [`enable_network()`](proj/struct.ProjBuilder.html#method.enable_network).  Network
+//! functionality status can be queried with `network_enabled`, and the download endpoint can be
+//! queried and set using `get_url_endpoint` and `set_url_endpoint`.
 //!
-//! let my_point = (4760096.421921f64, 3744293.729449f64);
+//! #### Grid File Cache
+//! Up to 300 mb of downloaded grids are cached to save bandwidth: This cache can be enabled or
+//! disabled using [`grid_cache_enable`](proj/struct.ProjBuilder.html#method.grid_cache_enable).
 //!
-//! let from = "EPSG:2230";
-//! let to = "EPSG:26946";
-//! let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
-//!
-//! let result = nad_ft_to_m
-//!     .convert(my_point)
-//!     .unwrap();
-//!
-//! assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
-//! assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
-//! ```
+//! ### Search Path Modification
+//! The path used to search for resource files can be modified using
+//! [`set_search_paths`](proj/struct.ProjBuilder.html#method.set_search_paths)
 //!
 //! ## Conform your own types
 //!
 //! If you have your own geometric types, you can conform them to the `Coord` trait and use `proj`
 //! without any intermediate allocation.
 //!
-//! ```
+//! ```rust
 //! # use assert_approx_eq::assert_approx_eq;
 //! use proj::{Proj, Coord};
 //!
@@ -129,8 +188,8 @@
 //!
 //! let result = proj.convert(donut_shop).unwrap();
 //!
-//! assert_approx_eq!(result.x(), 158458.67251293268, 1.0e-2);
-//! assert_approx_eq!(result.y(), -434296.8803996085, 1.0e-2);
+//! assert_approx_eq!(result.x(), 158458.67251293268);
+//! assert_approx_eq!(result.y(), -434296.8803996085);
 //! ```
 #![cfg_attr(
     feature = "geo-types",
@@ -140,7 +199,7 @@
 If you've enabled the `geo-types` feature, you can skip allocating an intermediate representation,
 and pass the [`geo-types`](https://crates.io/crates/geo-types) directly.
 
-```
+```rust
 # use assert_approx_eq::assert_approx_eq;
 use proj::Proj;
 use geo_types::Point;
@@ -153,8 +212,8 @@ let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 
 let result = nad_ft_to_m.convert(my_point).unwrap();
 
-assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
-assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
+assert_approx_eq!(result.x(), 1450880.29f64);
+assert_approx_eq!(result.y(), 1141263.01f64);
 ```
 "##
 )]
@@ -171,8 +230,8 @@ mod geo_types;
 mod proj;
 
 pub use crate::proj::Area;
-pub use crate::proj::Info;
 pub use crate::proj::Coord;
+pub use crate::proj::Info;
 pub use crate::proj::Proj;
 pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,13 @@
 //! explains the distinction between these operations in more detail.
 //!
 //! Out of the box, any `(x, y)` numeric tuple can be provided as input to proj. You can [conform
-//! your own types](#conform-your-own-types) to the [Point](proj/trait.Point.html) trait to pass
+//! your own types](#conform-your-own-types) to the [Coord](proj/trait.Coord.html) trait to pass
 //! them in directly and avoid intermediate allocations. There is a [`geo-types`
 //! feature](#feature-flags) to enable such impl's for users of the the [`geo-types`
 //! crate](https://docs.rs/geo-types).
 //!
 //! Methods for [conversion](struct.Proj.html#method.convert_array) and
-//! [projection](struct.Proj.html#method.project_array) of slices of `Point`s are also available.
+//! [projection](struct.Proj.html#method.project_array) of slices of `Coord`s are also available.
 //!
 //! # Usage
 //!
@@ -62,7 +62,7 @@
 //!## Feature Flags
 //!
 //! - `geo-types`: include [trait impls for
-//! `geo-types`](proj/trait.Point.html#impl-Point%3CT%3E-for-Coordinate%3CT%3E). See
+//! `geo-types`](proj/trait.Coord.html#impl-Coord%3CT%3E-for-Coordinate%3CT%3E). See
 //!   [example](#integration-with-geo-types).
 //! - `pkg_config`: enables the use of `pkg-config` when linking against `libproj` —
 //!   note that `pkg-config` must be available on your system.
@@ -79,7 +79,7 @@
 //!
 //! ```
 //! # use assert_approx_eq::assert_approx_eq;
-//! use proj::{Proj, Point};
+//! use proj::{Proj, Coord};
 //!
 //! let my_point = (4760096.421921f64, 3744293.729449f64);
 //!
@@ -97,19 +97,19 @@
 //!
 //! ## Conform your own types
 //!
-//! If you have your own geometric types, you can conform them to the `Point` trait and use `proj`
+//! If you have your own geometric types, you can conform them to the `Coord` trait and use `proj`
 //! without any intermediate allocation.
 //!
 //! ```
 //! # use assert_approx_eq::assert_approx_eq;
-//! use proj::{Proj, Point};
+//! use proj::{Proj, Coord};
 //!
 //! struct MyPointOfIntereset {
 //!     lat: f64,
 //!     lon: f64,
 //! }
 //!
-//! impl Point<f64> for MyPointOfIntereset {
+//! impl Coord<f64> for MyPointOfIntereset {
 //!     fn x(&self) -> f64 {
 //!         self.lon
 //!     }
@@ -172,7 +172,7 @@ mod proj;
 
 pub use crate::proj::Area;
 pub use crate::proj::Info;
-pub use crate::proj::Point;
+pub use crate::proj::Coord;
 pub use crate::proj::Proj;
 pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,16 +66,13 @@
 //! ```
 //! use assert_approx_eq::assert_approx_eq;
 //! extern crate proj;
-//! use proj::Proj;
-//!
-//! extern crate geo_types;
-//! use geo_types::Point;
+//! use proj::{Proj, Point};
 //!
 //! let from = "EPSG:2230";
 //! let to = "EPSG:26946";
 //! let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 //! let result = nad_ft_to_m
-//!     .convert(Point::new(4760096.421921f64, 3744293.729449f64))
+//!     .convert((4760096.421921f64, 3744293.729449f64))
 //!     .unwrap();
 //! assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
 //! assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
@@ -89,6 +86,7 @@ mod proj;
 
 pub use crate::proj::Area;
 pub use crate::proj::Info;
+pub use crate::proj::Point;
 pub use crate::proj::Proj;
 pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,8 +212,8 @@ let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 
 let result = nad_ft_to_m.convert(my_point).unwrap();
 
-assert_approx_eq!(result.x(), 1450880.29f64);
-assert_approx_eq!(result.y(), 1141263.01f64);
+assert_approx_eq!(result.x(), 1450880.2910605003f64);
+assert_approx_eq!(result.y(), 1141263.0111604529f64);
 ```
 "##
 )]

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -819,7 +819,7 @@ mod test {
         assert!(f > 0.99999);
     }
 
-    #[cfg(feature="network")]
+    #[cfg(feature = "network")]
     #[test]
     fn test_network_enabled_conversion() {
         // OSGB 1936
@@ -837,7 +837,7 @@ mod test {
         assert_eq!(online_builder.network_enabled(), true);
         assert_eq!(offline_builder.network_enabled(), false);
 
-        // Disable caching to ensure we're accessing the network. 
+        // Disable caching to ensure we're accessing the network.
         // Cache is stored in proj's [user writeable directory](https://proj.org/resource_files.html#user-writable-directory)
         online_builder.grid_cache_enable(false);
 
@@ -847,8 +847,12 @@ mod test {
 
         // download begins here:
         // File to download: uk_os_OSTN15_NTv2_OSGBtoETRS.tif
-        let online_t = online_proj.convert(MyPoint::new(0.001653, 52.267733)).unwrap();
-        let offline_t = offline_proj.convert(MyPoint::new(0.001653, 52.267733)).unwrap();
+        let online_t = online_proj
+            .convert(MyPoint::new(0.001653, 52.267733))
+            .unwrap();
+        let offline_t = offline_proj
+            .convert(MyPoint::new(0.001653, 52.267733))
+            .unwrap();
 
         // Grid download results in a high-quality OSTN15 conversion
         assert_almost_eq(online_t.x(), 0.000026091248979289044);

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1,7 +1,6 @@
-use geo_types::Point;
 use libc::c_int;
 use libc::{c_char, c_double};
-use num_traits::Float;
+use num_traits::{Float, Num, NumCast};
 use proj_sys::{
     proj_area_create, proj_area_destroy, proj_area_set_bbox, proj_cleanup, proj_context_create,
     proj_context_destroy, proj_context_get_url_endpoint, proj_context_is_network_enabled,
@@ -21,6 +20,30 @@ use std::ffi::CString;
 use std::path::Path;
 use std::str;
 use thiserror::Error;
+
+pub trait CoordinateType: Num + Copy + NumCast + PartialOrd {}
+impl<T: Num + Copy + NumCast + PartialOrd> CoordinateType for T {}
+
+pub trait Point<T>
+where
+    T: CoordinateType,
+{
+    fn x(&self) -> T;
+    fn y(&self) -> T;
+    fn from_xy(x: T, y: T) -> Self;
+}
+
+impl<T: CoordinateType> Point<T> for (T, T) {
+    fn x(&self) -> T {
+        self.0
+    }
+    fn y(&self) -> T {
+        self.1
+    }
+    fn from_xy(x: T, y: T) -> Self {
+        (x, y)
+    }
+}
 
 /// Errors originating in PROJ which can occur during projection and conversion
 #[derive(Error, Debug)]
@@ -357,16 +380,13 @@ impl ProjBuilder {
     ///```rust
     /// # use assert_approx_eq::assert_approx_eq;
     /// extern crate proj;
-    /// use proj::Proj;
-    ///
-    /// extern crate geo_types;
-    /// use geo_types::Point;
+    /// use proj::{Proj, Point};
     ///
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
     /// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
     /// let result = nad_ft_to_m
-    ///     .convert(Point::new(4760096.421921f64, 3744293.729449f64))
+    ///     .convert((4760096.421921f64, 3744293.729449f64))
     ///     .unwrap();
     /// assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
     /// assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
@@ -438,16 +458,13 @@ impl Proj {
     ///```rust
     /// # use assert_approx_eq::assert_approx_eq;
     /// extern crate proj;
-    /// use proj::Proj;
-    ///
-    /// extern crate geo_types;
-    /// use geo_types::Point;
+    /// use proj::{Proj, Point};
     ///
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
     /// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
     /// let result = nad_ft_to_m
-    ///     .convert(Point::new(4760096.421921f64, 3744293.729449f64))
+    ///     .convert((4760096.421921f64, 3744293.729449f64))
     ///     .unwrap();
     /// assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
     /// assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
@@ -500,19 +517,18 @@ impl Proj {
     ///
     /// # Safety
     /// This method contains unsafe code.
-    pub fn project<T, U>(&self, point: T, inverse: bool) -> Result<Point<U>, ProjError>
+    pub fn project<P, F>(&self, point: P, inverse: bool) -> Result<P, ProjError>
     where
-        T: Into<Point<U>>,
-        U: Float,
+        P: Point<F>,
+        F: Float,
     {
         let inv = if inverse {
             PJ_DIRECTION_PJ_INV
         } else {
             PJ_DIRECTION_PJ_FWD
         };
-        let _point: Point<U> = point.into();
-        let c_x: c_double = _point.x().to_f64().ok_or(ProjError::FloatConversion)?;
-        let c_y: c_double = _point.y().to_f64().ok_or(ProjError::FloatConversion)?;
+        let c_x: c_double = point.x().to_f64().ok_or(ProjError::FloatConversion)?;
+        let c_y: c_double = point.y().to_f64().ok_or(ProjError::FloatConversion)?;
         let new_x;
         let new_y;
         let err;
@@ -531,9 +547,9 @@ impl Proj {
             err = proj_errno(self.c_proj);
         }
         if err == 0 {
-            Ok(Point::new(
-                U::from(new_x).ok_or(ProjError::FloatConversion)?,
-                U::from(new_y).ok_or(ProjError::FloatConversion)?,
+            Ok(Point::from_xy(
+                F::from(new_x).ok_or(ProjError::FloatConversion)?,
+                F::from(new_y).ok_or(ProjError::FloatConversion)?,
             ))
         } else {
             Err(ProjError::Projection(error_message(err)?))
@@ -561,16 +577,13 @@ impl Proj {
     /// ```rust
     /// # use assert_approx_eq::assert_approx_eq;
     /// extern crate proj;
-    /// use proj::Proj;
-    ///
-    /// extern crate geo_types;
-    /// use geo_types::Point;
+    /// use proj::{Proj, Point};
     ///
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
     /// let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
     /// let result = ft_to_m
-    ///     .convert(Point::new(4760096.421921, 3744293.729449))
+    ///     .convert((4760096.421921, 3744293.729449))
     ///     .unwrap();
     /// assert_approx_eq!(result.x() as f64, 1450880.2910605003);
     /// assert_approx_eq!(result.y() as f64, 1141263.0111604529);
@@ -578,14 +591,13 @@ impl Proj {
     ///
     /// # Safety
     /// This method contains unsafe code.
-    pub fn convert<T, U>(&self, point: T) -> Result<Point<U>, ProjError>
+    pub fn convert<P, F>(&self, point: P) -> Result<P, ProjError>
     where
-        T: Into<Point<U>>,
-        U: Float,
+        P: Point<F>,
+        F: Float,
     {
-        let _point: Point<U> = point.into();
-        let c_x: c_double = _point.x().to_f64().ok_or(ProjError::FloatConversion)?;
-        let c_y: c_double = _point.y().to_f64().ok_or(ProjError::FloatConversion)?;
+        let c_x: c_double = point.x().to_f64().ok_or(ProjError::FloatConversion)?;
+        let c_y: c_double = point.y().to_f64().ok_or(ProjError::FloatConversion)?;
         let new_x;
         let new_y;
         let err;
@@ -598,9 +610,9 @@ impl Proj {
             err = proj_errno(self.c_proj);
         }
         if err == 0 {
-            Ok(Point::new(
-                U::from(new_x).ok_or(ProjError::FloatConversion)?,
-                U::from(new_y).ok_or(ProjError::FloatConversion)?,
+            Ok(P::from_xy(
+                F::from(new_x).ok_or(ProjError::FloatConversion)?,
+                F::from(new_y).ok_or(ProjError::FloatConversion)?,
             ))
         } else {
             Err(ProjError::Conversion(error_message(err)?))
@@ -619,16 +631,15 @@ impl Proj {
     /// to Longitude, Latitude / Easting, Northing.
     ///
     /// ```rust
-    /// use proj::Proj;
-    /// extern crate geo_types;
-    /// use geo_types::Point;
+    /// use proj::{Proj, Point};
+    ///
     /// # use assert_approx_eq::assert_approx_eq;
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
     /// let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
     /// let mut v = vec![
-    ///     Point::new(4760096.421921, 3744293.729449),
-    ///     Point::new(4760197.421921, 3744394.729449),
+    ///     (4760096.421921, 3744293.729449),
+    ///     (4760197.421921, 3744394.729449),
     /// ];
     /// ft_to_m.convert_array(&mut v);
     /// assert_approx_eq!(v[0].x(), 1450880.2910605003f64);
@@ -639,12 +650,10 @@ impl Proj {
     /// This method contains unsafe code.
     // TODO: there may be a way of avoiding some allocations, but transmute won't work because
     // PJ_COORD and Point<T> are different sizes
-    pub fn convert_array<'a, T>(
-        &self,
-        points: &'a mut [Point<T>],
-    ) -> Result<&'a mut [Point<T>], ProjError>
+    pub fn convert_array<'a, P, F>(&self, points: &'a mut [P]) -> Result<&'a mut [P], ProjError>
     where
-        T: Float,
+        P: Point<F>,
+        F: Float,
     {
         self.array_general(points, Transformation::Conversion, false)
     }
@@ -655,9 +664,8 @@ impl Proj {
     /// (in radians) from the projection specified by `definition`.
     ///
     /// ```rust
-    /// use proj::Proj;
-    /// extern crate geo_types;
-    /// use geo_types::Point;
+    /// use proj::{Proj, Point};
+    ///
     /// # use assert_approx_eq::assert_approx_eq;
     /// let stereo70 = Proj::new(
     ///     "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000
@@ -665,7 +673,7 @@ impl Proj {
     /// )
     /// .unwrap();
     /// // Geodetic -> Pulkovo 1942(58) / Stereo70 (EPSG 3844)
-    /// let mut v = vec![Point::new(0.436332, 0.802851)];
+    /// let mut v = vec![(0.436332, 0.802851)];
     /// let t = stereo70.project_array(&mut v, false).unwrap();
     /// assert_approx_eq!(v[0].x(), 500119.7035366755f64);
     /// assert_approx_eq!(v[0].y(), 500027.77901023754f64);
@@ -675,13 +683,14 @@ impl Proj {
     /// This method contains unsafe code.
     // TODO: there may be a way of avoiding some allocations, but transmute won't work because
     // PJ_COORD and Point<T> are different sizes
-    pub fn project_array<'a, T>(
+    pub fn project_array<'a, P, F>(
         &self,
-        points: &'a mut [Point<T>],
+        points: &'a mut [P],
         inverse: bool,
-    ) -> Result<&'a mut [Point<T>], ProjError>
+    ) -> Result<&'a mut [P], ProjError>
     where
-        T: Float,
+        P: Point<F>,
+        F: Float,
     {
         self.array_general(points, Transformation::Projection, inverse)
     }
@@ -689,14 +698,15 @@ impl Proj {
     // array conversion and projection logic is almost identical;
     // transform points in input array into PJ_COORD, transform them, error-check, then re-fill
     // input slice with points. Only the actual transformation ops vary slightly.
-    fn array_general<'a, T>(
+    fn array_general<'a, P, F>(
         &self,
-        points: &'a mut [Point<T>],
+        points: &'a mut [P],
         op: Transformation,
         inverse: bool,
-    ) -> Result<&'a mut [Point<T>], ProjError>
+    ) -> Result<&'a mut [P], ProjError>
     where
-        T: Float,
+        P: Point<F>,
+        F: Float,
     {
         let err;
         let trans;
@@ -736,9 +746,9 @@ impl Proj {
             // feels a bit clunky, but we're guaranteed that pj and points have the same length
             unsafe {
                 for (i, coord) in pj.iter().enumerate() {
-                    points[i] = Point::new(
-                        T::from(coord.xy.x).ok_or(ProjError::FloatConversion)?,
-                        T::from(coord.xy.y).ok_or(ProjError::FloatConversion)?,
+                    points[i] = Point::from_xy(
+                        F::from(coord.xy.x).ok_or(ProjError::FloatConversion)?,
+                        F::from(coord.xy.y).ok_or(ProjError::FloatConversion)?,
                     )
                 }
             }
@@ -776,7 +786,32 @@ impl Drop for ProjBuilder {
 #[cfg(test)]
 mod test {
     use super::*;
-    use geo_types::Point;
+
+    #[derive(Debug)]
+    struct MyPoint {
+        x: f64,
+        y: f64,
+    }
+
+    impl MyPoint {
+        fn new(x: f64, y: f64) -> Self {
+            MyPoint { x, y }
+        }
+    }
+
+    impl Point<f64> for MyPoint {
+        fn x(&self) -> f64 {
+            self.x
+        }
+
+        fn y(&self) -> f64 {
+            self.y
+        }
+
+        fn from_xy(x: f64, y: f64) -> Self {
+            MyPoint { x, y }
+        }
+    }
 
     fn assert_almost_eq(a: f64, b: f64) {
         let f: f64 = a / b;
@@ -812,8 +847,8 @@ mod test {
 
         // download begins here:
         // File to download: uk_os_OSTN15_NTv2_OSGBtoETRS.tif
-        let online_t = online_proj.convert(Point::new(0.001653, 52.267733)).unwrap();
-        let offline_t = offline_proj.convert(Point::new(0.001653, 52.267733)).unwrap();
+        let online_t = online_proj.convert(MyPoint::new(0.001653, 52.267733)).unwrap();
+        let offline_t = offline_proj.convert(MyPoint::new(0.001653, 52.267733)).unwrap();
 
         // Grid download results in a high-quality OSTN15 conversion
         assert_almost_eq(online_t.x(), 0.000026091248979289044);
@@ -863,7 +898,7 @@ mod test {
         let to = "EPSG:26946";
         let proj = Proj::new_known_crs(&from, &to, None).unwrap();
         let t = proj
-            .convert(Point::new(4760096.421921, 3744293.729449))
+            .convert(MyPoint::new(4760096.421921, 3744293.729449))
             .unwrap();
         assert_almost_eq(t.x(), 1450880.29);
         assert_almost_eq(t.y(), 1141263.01);
@@ -878,7 +913,7 @@ mod test {
         .unwrap();
         // Geodetic -> Pulkovo 1942(58) / Stereo70 (EPSG 3844)
         let t = stereo70
-            .project(Point::new(0.436332, 0.802851), false)
+            .project(MyPoint::new(0.436332, 0.802851), false)
             .unwrap();
         assert_almost_eq(t.x(), 500119.7035366755);
         assert_almost_eq(t.y(), 500027.77901023754);
@@ -893,7 +928,7 @@ mod test {
         .unwrap();
         // Pulkovo 1942(58) / Stereo70 (EPSG 3844) -> Geodetic
         let t = stereo70
-            .project(Point::new(500119.70352012233, 500027.77896348457), true)
+            .project(MyPoint::new(500119.70352012233, 500027.77896348457), true)
             .unwrap();
         assert_almost_eq(t.x(), 0.436332);
         assert_almost_eq(t.y(), 0.802851);
@@ -910,7 +945,7 @@ mod test {
         .unwrap();
         // OSGB36 (EPSG 27700) -> Geodetic
         let t = osgb36
-            .project(Point::new(548295.39, 182498.46), true)
+            .project(MyPoint::new(548295.39, 182498.46), true)
             .unwrap();
         assert_almost_eq(t.x(), 0.0023755864848281206);
         assert_almost_eq(t.y(), 0.8992274896304518);
@@ -930,7 +965,7 @@ mod test {
         ").unwrap();
         // Presidio, San Francisco
         let t = nad83_m
-            .convert(Point::new(4760096.421921, 3744293.729449))
+            .convert(MyPoint::new(4760096.421921, 3744293.729449))
             .unwrap();
         assert_almost_eq(t.x(), 1450880.29);
         assert_almost_eq(t.y(), 1141263.01);
@@ -948,7 +983,7 @@ mod test {
         )
         .unwrap();
         let err = nad83_m
-            .convert(Point::new(4760096.421921, 3744293.729449))
+            .convert(MyPoint::new(4760096.421921, 3744293.729449))
             .unwrap_err();
         assert_eq!(
             "The conversion failed with the following error: latitude or longitude exceeded limits",
@@ -965,17 +1000,17 @@ mod test {
 
         // we expect this first conversion to fail (copied from above test case)
         assert!(nad83_m
-            .convert(Point::new(4760096.421921, 3744293.729449))
+            .convert(MyPoint::new(4760096.421921, 3744293.729449))
             .is_err());
 
         // but a subsequent valid conversion should still be successful
-        assert!(nad83_m.convert(Point::new(0.0, 0.0)).is_ok());
+        assert!(nad83_m.convert(MyPoint::new(0.0, 0.0)).is_ok());
 
         // also test with project() function
         assert!(nad83_m
-            .project(Point::new(99999.0, 99999.0), false)
+            .project(MyPoint::new(99999.0, 99999.0), false)
             .is_err());
-        assert!(nad83_m.project(Point::new(0.0, 0.0), false).is_ok());
+        assert!(nad83_m.project(MyPoint::new(0.0, 0.0), false).is_ok());
     }
 
     #[test]
@@ -984,8 +1019,8 @@ mod test {
         let to = "EPSG:26946";
         let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
         let mut v = vec![
-            Point::new(4760096.421921, 3744293.729449),
-            Point::new(4760197.421921, 3744394.729449),
+            MyPoint::new(4760096.421921, 3744293.729449),
+            MyPoint::new(4760197.421921, 3744394.729449),
         ];
         ft_to_m.convert_array(&mut v).unwrap();
         assert_almost_eq(v[0].x(), 1450880.2910605003f64);
@@ -1000,7 +1035,7 @@ mod test {
         let to = "EPSG:2230";
         let to_feet = Proj::new_known_crs(&from, &to, None).unwrap();
         // 👽
-        let usa_m = Point::new(-115.797615, 37.2647978);
+        let usa_m = MyPoint::new(-115.797615, 37.2647978);
         let usa_ft = to_feet.convert(usa_m).unwrap();
         assert_eq!(6693625.67217475, usa_ft.x());
         assert_eq!(3497301.5918027186, usa_ft.y());

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -24,6 +24,13 @@ use thiserror::Error;
 pub trait CoordinateType: Num + Copy + NumCast + PartialOrd {}
 impl<T: Num + Copy + NumCast + PartialOrd> CoordinateType for T {}
 
+/// A point in two dimensional space. The primary unit of input/output for proj.
+///
+/// By default, any numeric `(x, y)` tuple implements `Point`, but you can conform your type to
+/// `Point` to pass it directly into proj.
+///
+/// See the [`geo-types` feature](#feature-flags) for interop with the [`geo-types`
+/// crate](https://docs.rs/crate/geo-types)
 pub trait Point<T>
 where
     T: CoordinateType,


### PR DESCRIPTION
It seems like the potential users of proj would include people who don't need/want to opt into the whole `geo` ecosystem.

What would you think about having the proj interface be trait-based and having the geo-integration be a feature?

If this seems like a reasonable direction, before merging I'd like to update the docs to show:

1. how you can use this with the greater `geo` ecosystem
2. how you can `impl` your own point type if you're not using geo.
3. how you can use the built-in `(Float, Float)` impl

WDYT @urschrei?