### PR TITLE
try to fix bors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           - container:
               image: "georust/proj-ci:latest"
               env:
-                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
             features: ""
           - container:
               image: "georust/proj-ci:latest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           - container:
               image: "georust/proj-ci:latest"
               env:
-                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
             features: ""
           - container:
               image: "georust/proj-ci:latest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,28 @@
 on: push
 name: proj ci
 jobs:
+  # The `ci-result` job doesn't actually test anything - it just aggregates the
+  # overall build status for bors, otherwise our bors.toml would need an entry
+  # for each individual job produced by the job-matrix.
+  #
+  # Ref: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
+  #
+  # ALL THE SUBSEQUENT JOBS NEED THEIR `name` ADDED TO THE `needs` SECTION OF THIS JOB!
+  ci-result:
+    name: ci result
+    runs-on: ubuntu-latest
+    needs:
+      - proj-ubuntu
+      - proj-sys-ubuntu
+      - proj-macos
+      - proj-sys-macos
+    steps:
+      - name: Mark the job as a success
+        if: success()
+        run: exit 0
+      - name: Mark the job as a failure
+        if: "!success()"
+        run: exit 1
   proj-ubuntu:
     name: proj ubuntu
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         features: ["", "--features network", "--features bundled_proj", "--features \"bundled_proj network\""]
     container:
-      image: "georust/proj-ci:latest"
+      image: georust/proj-ci:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -63,12 +63,12 @@ jobs:
       matrix:
         include:
           - container:
-              image: "georust/proj-ci:latest"
+              image: georust/proj-ci:latest
               env:
                 _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
             features: ""
           - container:
-              image: "georust/proj-ci:latest"
+              image: georust/proj-ci:latest
               env:
                 _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
             features: "--features bundled_proj"

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
 status = [
-    "proj ci",
+    "ci result",
 ]

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,3 @@
 status = [
-    "proj ubuntu",
-    "proj-sys ubuntu",
-    "proj macos",
-    "proj-sys macos",
+    "proj ci",
 ]


### PR DESCRIPTION
Can we just use the overall workflow name? Or do we need to enumerate
job names? There are a lot of job names...