### PR TITLE
use `approx` for better failure output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ pkg_config = [ "proj-sys/pkg_config" ]
 network = ["reqwest"]
 
 [dev-dependencies]
-assert_approx_eq = "1.1.0"
+approx = "0.3"
 
 [package.metadata.docs.rs]
 features = [ "proj-sys/nobuild", "network", "geo-types" ]

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 let result = ft_to_m
     .convert((4760096.421921f64, 3744293.729449f64))
     .unwrap();
-assert_approx_eq!(result.0, 1450880.2910605003);
-assert_approx_eq!(result.1, 1141263.0111604529);
+assert_relative_eq!(result.0, 1450880.2910605003);
+assert_relative_eq!(result.1, 1141263.0111604529);
 ```
 
 ### Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using the `pipeline` Operator
@@ -71,8 +71,8 @@ let ft_to_m = Proj::new("
 
 // The Presidio, approximately
 let result = ft_to_m.convert((4760096.421921f64, 3744293.729449f64)).unwrap();
-assert_approx_eq!(result.0, 1450880.2910605003);
-assert_approx_eq!(result.1, 1141263.01116045);
+assert_relative_eq!(result.0, 1450880.2910605003);
+assert_relative_eq!(result.1, 1141263.01116045);
 ```
 
 ### Inverse Projection from [Stereo70](https://epsg.io/3844) to Geodetic
@@ -90,8 +90,8 @@ let stereo70 = Proj::new("
 let geodetic_radians_point = stereo70.project(
     (500119.70352012233f64, 500027.77896348457f64), true
 ).unwrap();
-assert_approx_eq!(geodetic_radians_point.0, 0.436332);
-assert_approx_eq!(geodetic_radians_point.1, 0.802851);
+assert_relative_eq!(geodetic_radians_point.0, 0.436332, epsilon=1e-5);
+assert_relative_eq!(geodetic_radians_point.1, 0.802851, epsiolon=1e-5);
 ```
 
 ## Usage
@@ -187,8 +187,8 @@ let proj = Proj::new_known_crs(&from, &to, None).unwrap();
 
 let result = proj.convert(donut_shop).unwrap();
 
-assert_approx_eq!(result.x(), 158458.67251293268);
-assert_approx_eq!(result.y(), -434296.8803996085);
+assert_relative_eq!(result.x(), 158458.67251293268);
+assert_relative_eq!(result.y(), -434296.8803996085);
 ```
 
 ### Integration with `geo-types`
@@ -197,7 +197,7 @@ If you've enabled the `geo-types` feature, you can skip allocating an intermedia
 and pass the [`geo-types`](https://crates.io/crates/geo-types) directly.
 
 ```rust
-# use assert_approx_eq::assert_approx_eq;
+# use approx::assert_relative_eq;
 use proj::Proj;
 use geo_types::Point;
 
@@ -209,8 +209,8 @@ let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 
 let result = nad_ft_to_m.convert(my_point).unwrap();
 
-assert_approx_eq!(result.x(), 1450880.2910605003f64);
-assert_approx_eq!(result.y(), 1141263.0111604529f64);
+assert_relative_eq!(result.x(), 1450880.2910605003f64);
+assert_relative_eq!(result.y(), 1141263.0111604529f64);
 ```
 
 License: MIT/Apache-2.0

--- a/proj-sys/src/lib.rs
+++ b/proj-sys/src/lib.rs
@@ -10,7 +10,7 @@
 //! [`proj`](https://github.com/georust/proj) crate for general use.
 //!
 //! A guide to the functions can be found here:
-//! https://proj.org/development/reference/functions.html.
+//! <https://proj.org/development/reference/functions.html>.
 //!
 //! By default, the crate will search for an existing `libproj` (via `PROJ v7.1.x`)
 //! installation on your system using

--- a/src/geo_types.rs
+++ b/src/geo_types.rs
@@ -1,5 +1,5 @@
 ///```rust
-/// # use assert_approx_eq::assert_approx_eq;
+/// # use approx::assert_relative_eq;
 /// extern crate proj;
 /// use proj::Proj;
 /// use geo_types::Coordinate;
@@ -10,8 +10,8 @@
 /// let result = nad_ft_to_m
 ///     .convert(Coordinate { x: 4760096.421921f64, y: 3744293.729449f64 })
 ///     .unwrap();
-/// assert_approx_eq!(result.x, 1450880.29f64, 1.0e-2);
-/// assert_approx_eq!(result.y, 1141263.01f64, 1.0e-2);
+/// assert_relative_eq!(result.x, 1450880.29f64, epsilon=1.0e-2);
+/// assert_relative_eq!(result.y, 1141263.01f64, epsilon=1.0e-2);
 /// ```
 impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Coordinate<T> {
     fn x(&self) -> T {
@@ -26,7 +26,7 @@ impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Coordinate<T
 }
 
 ///```rust
-/// # use assert_approx_eq::assert_approx_eq;
+/// # use approx::assert_relative_eq;
 /// extern crate proj;
 /// use proj::Proj;
 /// use geo_types::Point;
@@ -37,8 +37,8 @@ impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Coordinate<T
 /// let result = nad_ft_to_m
 ///     .convert(Point::new(4760096.421921f64, 3744293.729449f64))
 ///     .unwrap();
-/// assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
-/// assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
+/// assert_relative_eq!(result.x(), 1450880.29f64, epsilon=1.0e-2);
+/// assert_relative_eq!(result.y(), 1141263.01f64, epsilon=1.0e-2);
 /// ```
 impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Point<T> {
     fn x(&self) -> T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! ## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using EPSG Codes
 //!
 //! ```rust
-//! # use assert_approx_eq::assert_approx_eq;
+//! # use approx::assert_relative_eq;
 //! use proj::Proj;
 //!
 //! let from = "EPSG:2230";
@@ -38,8 +38,8 @@
 //! let result = ft_to_m
 //!     .convert((4760096.421921f64, 3744293.729449f64))
 //!     .unwrap();
-//! assert_approx_eq!(result.0, 1450880.2910605003);
-//! assert_approx_eq!(result.1, 1141263.0111604529);
+//! assert_relative_eq!(result.0, 1450880.29, epsilon=1e-2);
+//! assert_relative_eq!(result.1, 1141263.01, epsilon=1e-2);
 //! ```
 //!
 //! ## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946) Using the `pipeline` Operator
@@ -54,7 +54,7 @@
 //!
 //!
 //! ```rust
-//! # use assert_approx_eq::assert_approx_eq;
+//! # use approx::assert_relative_eq;
 //! use proj::Proj;
 //!
 //! let ft_to_m = Proj::new("
@@ -70,14 +70,14 @@
 //!
 //! // The Presidio, approximately
 //! let result = ft_to_m.convert((4760096.421921f64, 3744293.729449f64)).unwrap();
-//! assert_approx_eq!(result.0, 1450880.2910605003);
-//! assert_approx_eq!(result.1, 1141263.01116045);
+//! assert_relative_eq!(result.0, 1450880.29, epsilon=1e-2);
+//! assert_relative_eq!(result.1, 1141263.01, epsilon=1e-2);
 //! ```
 //!
 //! ## Inverse Projection from [Stereo70](https://epsg.io/3844) to Geodetic
 //!
 //! ```rust
-//! # use assert_approx_eq::assert_approx_eq;
+//! # use approx::assert_relative_eq;
 //! use proj::Proj;
 //!
 //! // Carry out an inverse projection from Pulkovo 1942(58) / Stereo70 (EPSG 3844)
@@ -90,8 +90,8 @@
 //! let geodetic_radians_point = stereo70.project(
 //!     (500119.70352012233f64, 500027.77896348457f64), true
 //! ).unwrap();
-//! assert_approx_eq!(geodetic_radians_point.0, 0.436332);
-//! assert_approx_eq!(geodetic_radians_point.1, 0.802851);
+//! assert_relative_eq!(geodetic_radians_point.0, 0.436332, epsilon=1e-5);
+//! assert_relative_eq!(geodetic_radians_point.1, 0.802851, epsilon=1e-5);
 //! ```
 //!
 //! # Usage
@@ -160,7 +160,7 @@
 //! without any intermediate allocation.
 //!
 //! ```rust
-//! # use assert_approx_eq::assert_approx_eq;
+//! # use approx::assert_relative_eq;
 //! use proj::{Proj, Coord};
 //!
 //! struct MyPointOfIntereset {
@@ -188,8 +188,8 @@
 //!
 //! let result = proj.convert(donut_shop).unwrap();
 //!
-//! assert_approx_eq!(result.x(), 158458.67251293268);
-//! assert_approx_eq!(result.y(), -434296.8803996085);
+//! assert_relative_eq!(result.x(), 158458.67, epsilon=1e-2);
+//! assert_relative_eq!(result.y(), -434296.88, epsilon=1e-2);
 //! ```
 #![cfg_attr(
     feature = "geo-types",
@@ -200,7 +200,7 @@ If you've enabled the `geo-types` feature, you can skip allocating an intermedia
 and pass the [`geo-types`](https://crates.io/crates/geo-types) directly.
 
 ```rust
-# use assert_approx_eq::assert_approx_eq;
+# use approx::assert_relative_eq;
 use proj::Proj;
 use geo_types::Point;
 
@@ -212,12 +212,11 @@ let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
 
 let result = nad_ft_to_m.convert(my_point).unwrap();
 
-assert_approx_eq!(result.x(), 1450880.2910605003f64);
-assert_approx_eq!(result.y(), 1141263.0111604529f64);
+assert_relative_eq!(result.x(), 1450880.29, epsilon=1e-2);
+assert_relative_eq!(result.y(), 1141263.01, epsilon=1e-2);
 ```
 "##
 )]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "network")]
@@ -226,6 +225,10 @@ mod network;
 #[cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "geo-types")]
 mod geo_types;
+
+#[cfg(test)]
+#[macro_use]
+extern crate approx;
 
 mod proj;
 

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -389,7 +389,7 @@ impl ProjBuilder {
     /// return correct results.
     ///
     ///```rust
-    /// # use assert_approx_eq::assert_approx_eq;
+    /// # use approx::assert_relative_eq;
     /// extern crate proj;
     /// use proj::{Proj, Coord};
     ///
@@ -399,8 +399,8 @@ impl ProjBuilder {
     /// let result = nad_ft_to_m
     ///     .convert((4760096.421921f64, 3744293.729449f64))
     ///     .unwrap();
-    /// assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
-    /// assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
+    /// assert_relative_eq!(result.x(), 1450880.29, epsilon = 1.0e-2);
+    /// assert_relative_eq!(result.y(), 1141263.01, epsilon = 1.0e-2);
     /// ```
     ///
     /// # Safety
@@ -467,7 +467,7 @@ impl Proj {
     /// return correct results.
     ///
     ///```rust
-    /// # use assert_approx_eq::assert_approx_eq;
+    /// # use approx::assert_relative_eq;
     /// extern crate proj;
     /// use proj::{Proj, Coord};
     ///
@@ -477,8 +477,8 @@ impl Proj {
     /// let result = nad_ft_to_m
     ///     .convert((4760096.421921f64, 3744293.729449f64))
     ///     .unwrap();
-    /// assert_approx_eq!(result.x(), 1450880.29f64, 1.0e-2);
-    /// assert_approx_eq!(result.y(), 1141263.01f64, 1.0e-2);
+    /// assert_relative_eq!(result.x(), 1450880.29, epsilon=1.0e-2);
+    /// assert_relative_eq!(result.y(), 1141263.01, epsilon=1.0e-2);
     /// ```
     ///
     /// # Safety
@@ -639,7 +639,7 @@ impl Proj {
     /// The following example converts from NAD83 US Survey Feet (EPSG 2230) to NAD83 Metres (EPSG 26946)
     ///
     /// ```rust
-    /// # use assert_approx_eq::assert_approx_eq;
+    /// # use approx::assert_relative_eq;
     /// extern crate proj;
     /// use proj::{Proj, Coord};
     ///
@@ -649,8 +649,8 @@ impl Proj {
     /// let result = ft_to_m
     ///     .convert((4760096.421921, 3744293.729449))
     ///     .unwrap();
-    /// assert_approx_eq!(result.x() as f64, 1450880.2910605003);
-    /// assert_approx_eq!(result.y() as f64, 1141263.0111604529);
+    /// assert_relative_eq!(result.x() as f64, 1450880.29, epsilon=1e-2);
+    /// assert_relative_eq!(result.y() as f64, 1141263.01, epsilon=1e-2);
     /// ```
     ///
     /// # Safety
@@ -697,7 +697,7 @@ impl Proj {
     /// ```rust
     /// use proj::{Proj, Coord};
     ///
-    /// # use assert_approx_eq::assert_approx_eq;
+    /// # use approx::assert_relative_eq;
     /// // Convert from NAD83(NSRS2007) to NAD83(2011)
     /// let from = "EPSG:4759";
     /// let to = "EPSG:4317";
@@ -707,8 +707,8 @@ impl Proj {
     ///     (-98.3166503906, 38.7112325390),
     /// ];
     /// NAD83_old_to_new.convert_array(&mut v);
-    /// assert_approx_eq!(v[0].x(), -98.5421513236f64);
-    /// assert_approx_eq!(v[1].y(), 38.7112325216f64);
+    /// assert_relative_eq!(v[0].x(), -98.54, epsilon=1e-2);
+    /// assert_relative_eq!(v[1].y(), 38.71, epsilon=1e-2);
     /// ```
     ///
     /// # Safety
@@ -731,7 +731,7 @@ impl Proj {
     /// ```rust
     /// use proj::{Proj, Coord};
     ///
-    /// # use assert_approx_eq::assert_approx_eq;
+    /// # use approx::assert_relative_eq;
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
     /// let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
@@ -740,8 +740,8 @@ impl Proj {
     ///     (4760197.421921, 3744394.729449),
     /// ];
     /// ft_to_m.convert_array(&mut v).unwrap();
-    /// assert_approx_eq!(v[0].x(), 1450880.2910605003f64);
-    /// assert_approx_eq!(v[1].y(), 1141293.7960220212f64);
+    /// assert_relative_eq!(v[0].x(), 1450880.29, epsilon=1e-2);
+    /// assert_relative_eq!(v[1].y(), 1141293.79, epsilon=1e-2);
     /// ```
     ///
     /// # Safety
@@ -880,12 +880,6 @@ mod test {
         }
     }
 
-    fn assert_almost_eq(a: f64, b: f64) {
-        let f: f64 = a / b;
-        assert!(f < 1.00001);
-        assert!(f > 0.99999);
-    }
-
     #[cfg(feature = "network")]
     #[test]
     fn test_network_enabled_conversion() {
@@ -922,12 +916,12 @@ mod test {
             .unwrap();
 
         // Grid download results in a high-quality OSTN15 conversion
-        assert_almost_eq(online_t.x(), 0.000026091248979289044);
-        assert_almost_eq(online_t.y(), 52.26817146070213);
+        assert_relative_eq!(online_t.x(), 0.000026091248979289044);
+        assert_relative_eq!(online_t.y(), 52.26817146070213);
 
         // Without the grid download, it's a less precise conversion
-        assert_almost_eq(offline_t.x(), -0.00000014658182154077693);
-        assert_almost_eq(offline_t.y(), 52.26815719726976);
+        assert_relative_eq!(offline_t.x(), -0.00000014658182154077693);
+        assert_relative_eq!(offline_t.y(), 52.26815719726976);
     }
 
     #[test]
@@ -971,8 +965,8 @@ mod test {
         let t = proj
             .convert(MyPoint::new(4760096.421921, 3744293.729449))
             .unwrap();
-        assert_almost_eq(t.x(), 1450880.29);
-        assert_almost_eq(t.y(), 1141263.01);
+        assert_relative_eq!(t.x(), 1450880.2910605003);
+        assert_relative_eq!(t.y(), 1141263.0111604529);
     }
     #[test]
     // Carry out a projection from geodetic coordinates
@@ -986,8 +980,8 @@ mod test {
         let t = stereo70
             .project(MyPoint::new(0.436332, 0.802851), false)
             .unwrap();
-        assert_almost_eq(t.x(), 500119.7035366755);
-        assert_almost_eq(t.y(), 500027.77901023754);
+        assert_relative_eq!(t.x(), 500119.7035366755, epsilon=1e-5);
+        assert_relative_eq!(t.y(), 500027.77901023754, epsilon=1e-5);
     }
     #[test]
     // Carry out an inverse projection to geodetic coordinates
@@ -1001,8 +995,8 @@ mod test {
         let t = stereo70
             .project(MyPoint::new(500119.70352012233, 500027.77896348457), true)
             .unwrap();
-        assert_almost_eq(t.x(), 0.436332);
-        assert_almost_eq(t.y(), 0.802851);
+        assert_relative_eq!(t.x(), 0.43633200013698786);
+        assert_relative_eq!(t.y(), 0.8028510000110507);
     }
     #[test]
     // Carry out an inverse projection to geodetic coordinates
@@ -1018,8 +1012,8 @@ mod test {
         let t = osgb36
             .project(MyPoint::new(548295.39, 182498.46), true)
             .unwrap();
-        assert_almost_eq(t.x(), 0.0023755864848281206);
-        assert_almost_eq(t.y(), 0.8992274896304518);
+        assert_relative_eq!(t.x(), 0.0023755864830313977);
+        assert_relative_eq!(t.y(), 0.89922748952037);
     }
     #[test]
     // Carry out a conversion from NAD83 feet (EPSG 2230) to NAD83 metres (EPSG 26946)
@@ -1038,8 +1032,8 @@ mod test {
         let t = nad83_m
             .convert(MyPoint::new(4760096.421921, 3744293.729449))
             .unwrap();
-        assert_almost_eq(t.x(), 1450880.29);
-        assert_almost_eq(t.y(), 1141263.01);
+        assert_relative_eq!(t.x(), 1450880.2910605003);
+        assert_relative_eq!(t.y(), 1141263.01116045);
     }
     #[test]
     // Test that instantiation fails wth bad proj string input
@@ -1094,8 +1088,8 @@ mod test {
             MyPoint::new(4760197.421921, 3744394.729449),
         ];
         ft_to_m.convert_array(&mut v).unwrap();
-        assert_almost_eq(v[0].x(), 1450880.2910605003f64);
-        assert_almost_eq(v[1].y(), 1141293.7960220212f64);
+        assert_relative_eq!(v[0].x(), 1450880.2910605003f64);
+        assert_relative_eq!(v[1].y(), 1141293.7960220198);
     }
 
     #[test]


### PR DESCRIPTION
Gives output like:
```
assert_relative_eq!(t.x(), 1450880.29)

    left  = 0.0
    right = 1450880.29
```

vs previously:
```
thread 'proj::test::test_london_inverse' panicked at 'assertion failed: f > 0.99999', src/proj.rs:885:9
```
