### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
-## Unreleased
+## 0.21.0
+- Updated to `geo-types` v0.7.0 and `reqwest` v0.11.0
 
 - TIFF support is now opt-in when building PROJ via the `bundled_proj` feature
     - <https://github.com/georust/proj/pull/58>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.20.6"
+version = "0.21.0"
 authors = [
     "The Georust Developers <mods@georust.org>"
 ]
@@ -14,11 +14,11 @@ edition = "2018"
 
 [dependencies]
 proj-sys = { version = "0.18.3", path = "proj-sys" }
-geo-types = { version = "0.6", optional = true }
+geo-types = { version = "0.7", optional = true }
 libc = "0.2.62"
 num-traits = "0.2.8"
 thiserror = "1.0.4"
-reqwest = { version = "0.10.6", optional = true, default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11.0", optional = true, default-features = false, features = ["blocking", "rustls-tls"] }
 
 [workspace]
 members = ["proj-sys"]

--- a/src/geo_types.rs
+++ b/src/geo_types.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 ///```rust
 /// # use approx::assert_relative_eq;
 /// extern crate proj;
@@ -13,7 +15,7 @@
 /// assert_relative_eq!(result.x, 1450880.29f64, epsilon=1.0e-2);
 /// assert_relative_eq!(result.y, 1141263.01f64, epsilon=1.0e-2);
 /// ```
-impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Coordinate<T> {
+impl<T: crate::proj::CoordinateType + Debug> crate::Coord<T> for geo_types::Coordinate<T> {
     fn x(&self) -> T {
         self.x
     }
@@ -40,7 +42,7 @@ impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Coordinate<T
 /// assert_relative_eq!(result.x(), 1450880.29f64, epsilon=1.0e-2);
 /// assert_relative_eq!(result.y(), 1141263.01f64, epsilon=1.0e-2);
 /// ```
-impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Point<T> {
+impl<T: crate::proj::CoordinateType + Debug> crate::Coord<T> for geo_types::Point<T> {
     fn x(&self) -> T {
         geo_types::Point::x(*self)
     }

--- a/src/geo_types.rs
+++ b/src/geo_types.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 ///```rust
 /// # use approx::assert_relative_eq;
 /// extern crate proj;
@@ -15,7 +13,7 @@ use std::fmt::Debug;
 /// assert_relative_eq!(result.x, 1450880.29f64, epsilon=1.0e-2);
 /// assert_relative_eq!(result.y, 1141263.01f64, epsilon=1.0e-2);
 /// ```
-impl<T: crate::proj::CoordinateType + Debug> crate::Coord<T> for geo_types::Coordinate<T> {
+impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Coordinate<T> {
     fn x(&self) -> T {
         self.x
     }
@@ -42,7 +40,7 @@ impl<T: crate::proj::CoordinateType + Debug> crate::Coord<T> for geo_types::Coor
 /// assert_relative_eq!(result.x(), 1450880.29f64, epsilon=1.0e-2);
 /// assert_relative_eq!(result.y(), 1141263.01f64, epsilon=1.0e-2);
 /// ```
-impl<T: crate::proj::CoordinateType + Debug> crate::Coord<T> for geo_types::Point<T> {
+impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Point<T> {
     fn x(&self) -> T {
         geo_types::Point::x(*self)
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -25,7 +25,6 @@ const MAX_RETRIES: u8 = 8;
 const RETRY_CODES: [u16; 4] = [429, 500, 502, 504];
 
 /// This struct is cast to `c_void`, then to `PROJ_NETWORK_HANDLE` so it can be passed around
-#[no_mangle]
 struct HandleData {
     request: reqwest::blocking::RequestBuilder,
     headers: reqwest::header::HeaderMap,

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use libc::c_int;
 use libc::{c_char, c_double};
 use num_traits::{Float, Num, NumCast};
@@ -23,8 +24,8 @@ use std::path::Path;
 use std::str;
 use thiserror::Error;
 
-pub trait CoordinateType: Num + Copy + NumCast + PartialOrd {}
-impl<T: Num + Copy + NumCast + PartialOrd> CoordinateType for T {}
+pub trait CoordinateType: Num + Copy + NumCast + PartialOrd + Debug {}
+impl<T: Num + Copy + NumCast + PartialOrd + Debug> CoordinateType for T {}
 
 /// A point in two dimensional space. The primary unit of input/output for proj.
 ///
@@ -584,7 +585,7 @@ impl Proj {
     pub fn project<C, F>(&self, point: C, inverse: bool) -> Result<C, ProjError>
     where
         C: Coord<F>,
-        F: Float,
+        F: Float + Debug,
     {
         let inv = if inverse {
             PJ_DIRECTION_PJ_INV
@@ -658,7 +659,7 @@ impl Proj {
     pub fn convert<C, F>(&self, point: C) -> Result<C, ProjError>
     where
         C: Coord<F>,
-        F: Float,
+        F: Float + Debug,
     {
         let c_x: c_double = point.x().to_f64().ok_or(ProjError::FloatConversion)?;
         let c_y: c_double = point.y().to_f64().ok_or(ProjError::FloatConversion)?;
@@ -718,7 +719,7 @@ impl Proj {
     pub fn convert_array<'a, C, F>(&self, points: &'a mut [C]) -> Result<&'a mut [C], ProjError>
     where
         C: Coord<F>,
-        F: Float,
+        F: Float + Debug,
     {
         self.array_general(points, Transformation::Conversion, false)
     }
@@ -755,7 +756,7 @@ impl Proj {
     ) -> Result<&'a mut [C], ProjError>
     where
         C: Coord<F>,
-        F: Float,
+        F: Float + Debug,
     {
         self.array_general(points, Transformation::Projection, inverse)
     }
@@ -771,7 +772,7 @@ impl Proj {
     ) -> Result<&'a mut [C], ProjError>
     where
         C: Coord<F>,
-        F: Float,
+        F: Float + Debug,
     {
         let err;
         let trans;

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1,4 +1,3 @@
-use std::fmt::Debug;
 use libc::c_int;
 use libc::{c_char, c_double};
 use num_traits::{Float, Num, NumCast};
@@ -11,6 +10,7 @@ use proj_sys::{
     proj_trans, proj_trans_array, PJconsts, PJ_AREA, PJ_CONTEXT, PJ_COORD, PJ_DIRECTION_PJ_FWD,
     PJ_DIRECTION_PJ_INV, PJ_INFO, PJ_LP, PJ_XY,
 };
+use std::fmt::Debug;
 
 #[cfg(feature = "network")]
 use proj_sys::proj_context_set_enable_network;
@@ -799,8 +799,7 @@ impl Proj {
         match op {
             Transformation::Conversion => unsafe {
                 proj_errno_reset(self.c_proj);
-                trans =
-                    proj_trans_array(self.c_proj, PJ_DIRECTION_PJ_FWD, pj.len(), mp);
+                trans = proj_trans_array(self.c_proj, PJ_DIRECTION_PJ_FWD, pj.len(), mp);
                 err = proj_errno(self.c_proj);
             },
             Transformation::Projection => unsafe {
@@ -981,8 +980,8 @@ mod test {
         let t = stereo70
             .project(MyPoint::new(0.436332, 0.802851), false)
             .unwrap();
-        assert_relative_eq!(t.x(), 500119.7035366755, epsilon=1e-5);
-        assert_relative_eq!(t.y(), 500027.77901023754, epsilon=1e-5);
+        assert_relative_eq!(t.x(), 500119.7035366755, epsilon = 1e-5);
+        assert_relative_eq!(t.y(), 500027.77901023754, epsilon = 1e-5);
     }
     #[test]
     // Carry out an inverse projection to geodetic coordinates

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1,6 +1,6 @@
 use libc::c_int;
 use libc::{c_char, c_double};
-use num_traits::{Float, Num, NumCast};
+use num_traits::Float;
 use proj_sys::{
     proj_area_create, proj_area_destroy, proj_area_set_bbox, proj_cleanup, proj_context_create,
     proj_context_destroy, proj_context_get_url_endpoint, proj_context_is_network_enabled,
@@ -24,8 +24,8 @@ use std::path::Path;
 use std::str;
 use thiserror::Error;
 
-pub trait CoordinateType: Num + Copy + NumCast + PartialOrd + Debug {}
-impl<T: Num + Copy + NumCast + PartialOrd + Debug> CoordinateType for T {}
+pub trait CoordinateType: Float + Copy + PartialOrd + Debug {}
+impl<T: Float + Copy + PartialOrd + Debug> CoordinateType for T {}
 
 /// A point in two dimensional space. The primary unit of input/output for proj.
 ///
@@ -585,7 +585,7 @@ impl Proj {
     pub fn project<C, F>(&self, point: C, inverse: bool) -> Result<C, ProjError>
     where
         C: Coord<F>,
-        F: Float + Debug,
+        F: CoordinateType,
     {
         let inv = if inverse {
             PJ_DIRECTION_PJ_INV
@@ -659,7 +659,7 @@ impl Proj {
     pub fn convert<C, F>(&self, point: C) -> Result<C, ProjError>
     where
         C: Coord<F>,
-        F: Float + Debug,
+        F: CoordinateType,
     {
         let c_x: c_double = point.x().to_f64().ok_or(ProjError::FloatConversion)?;
         let c_y: c_double = point.y().to_f64().ok_or(ProjError::FloatConversion)?;
@@ -719,7 +719,7 @@ impl Proj {
     pub fn convert_array<'a, C, F>(&self, points: &'a mut [C]) -> Result<&'a mut [C], ProjError>
     where
         C: Coord<F>,
-        F: Float + Debug,
+        F: CoordinateType,
     {
         self.array_general(points, Transformation::Conversion, false)
     }
@@ -756,7 +756,7 @@ impl Proj {
     ) -> Result<&'a mut [C], ProjError>
     where
         C: Coord<F>,
-        F: Float + Debug,
+        F: CoordinateType,
     {
         self.array_general(points, Transformation::Projection, inverse)
     }
@@ -772,7 +772,7 @@ impl Proj {
     ) -> Result<&'a mut [C], ProjError>
     where
         C: Coord<F>,
-        F: Float + Debug,
+        F: CoordinateType,
     {
         let err;
         let trans;


### PR DESCRIPTION
This bumps `geo-types` to v0.7.0 and `reqwest` to v0.11.0 (the latter is a breaking change so we're bumping the minor version too.