### PR TITLE
Refactor PROJ thread context handling

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,50 @@
+use std::ptr;
+
+/// PROJ thread context
+pub struct ThreadContext(ptr::NonNull<proj_sys::PJ_CONTEXT>);
+
+impl ThreadContext {
+    pub fn new() -> Self {
+        // Safety: `proj_context_clone` always returns a valid pointer to a thread context.
+        unsafe {
+            let ctx_ptr = proj_sys::proj_context_create();
+            ThreadContext::from_raw(ctx_ptr)
+        }
+    }
+
+    /// # Safety
+    ///
+    /// Must provide a non-null pointer to a PROJ thread context.
+    unsafe fn from_raw(ctx_ptr: *mut proj_sys::PJ_CONTEXT) -> Self {
+        debug_assert!(!ctx_ptr.is_null());
+        ThreadContext(ptr::NonNull::new_unchecked(ctx_ptr))
+    }
+
+    pub fn as_ptr(&self) -> *mut proj_sys::PJ_CONTEXT {
+        self.0.as_ptr()
+    }
+}
+
+impl Clone for ThreadContext {
+    fn clone(&self) -> Self {
+        // Safety: `proj_context_clone` always returns a valid pointer to a thread context.
+        unsafe {
+            let ctx_ptr = proj_sys::proj_context_clone(self.0.as_ptr());
+            ThreadContext::from_raw(ctx_ptr)
+        }
+    }
+}
+
+impl Default for ThreadContext {
+    fn default() -> Self {
+        ThreadContext::new()
+    }
+}
+
+impl Drop for ThreadContext {
+    fn drop(&mut self) {
+        // Safety: The pointer being provided to `proj_context_destroy` will always be a valid
+        // thread context, so long as the same `ThreadContext` doesn't get dropped twice.
+        unsafe { proj_sys::proj_context_destroy(self.0.as_ptr()) };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,7 @@ mod geo_types;
 #[macro_use]
 extern crate approx;
 
+mod context;
 mod proj;
 
 pub use crate::proj::Area;


### PR DESCRIPTION
This pull request contains a new opaque struct `ThreadContext` that contains all thread context handling.

One benefit of this is the `Drop` implementations for `Proj` and `ProjBuilder` no longer need to handle destroying the thread context since that's now handled by the `Drop` implementation for `ThreadContext`. Also, [`ThreadContext` now implements `Clone`](https://github.com/georust/proj/blob/c553de24a2c62452a9bfd89312757d611fc52c61/src/context.rs#L28-L36), which gets us one step closer to implementing `Clone` for `Proj`. I chose the `ThreadContext` name because it's a little more descriptive than `Context` and the PROJ docs call this concept a ["thread context"](https://proj.org/development/threads.html#projctx). I created a separate file for it because I noticed `proj.rs` is getting on the larger side.