### PR TITLE
add support of vcpkg with msvc toolchain

### DIFF
--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -19,6 +19,10 @@ cmake = "0.1"
 flate2 = "1.0.14"
 tar = "0.4.26"
 
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2.11"
+winapi-build = "0.1.1"
+
 [features]
 nobuild = []
 bundled_proj = []

--- a/proj-sys/build.rs
+++ b/proj-sys/build.rs
@@ -3,12 +3,65 @@ use cmake;
 use flate2::read::GzDecoder;
 use std::fs::File;
 
+#[cfg(target_env = "msvc")]
+use vcpkg;
+#[cfg(target_env = "msvc")]
+use build;
 use pkg_config;
 use std::env;
 use std::path::PathBuf;
 use tar::Archive;
 
 const MINIMUM_PROJ_VERSION: &str = "7.2.1";
+
+#[cfg(target_env = "msvc")]
+fn try_vcpkg() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    build::link("shell32", true);
+    build::link("ole32", true);
+    let lib = vcpkg::Config::new()
+    .emit_includes(true)
+    .find_package("proj");
+
+    if let Err(_e) = lib {
+        return try_pkg_config()
+    }
+
+    let include_path = lib.unwrap()
+        .include_paths[0]
+        .clone();
+
+    Ok(include_path)
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn try_vcpkg() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    try_pkg_config()
+}
+
+fn try_pkg_config() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    pkg_config::Config::new()
+    .atleast_version(MINIMUM_PROJ_VERSION)
+    .probe("proj")
+    .and_then(|pk| {
+        eprintln!("found acceptable libproj already installed at: {:?}", pk.link_paths[0]);
+        if let Ok(val) = &env::var("_PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC") {
+            if val != "0" {
+                panic!("for testing purposes: existing package was found, but should not have been");
+            }
+        }
+
+        // Tell cargo to tell rustc to link the system proj
+        // shared library.
+        println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
+        println!("cargo:rustc-link-lib=proj");
+
+        Ok(pk.include_paths[0].clone())
+    })
+    .or_else(|err| {
+        eprintln!("pkg-config unable to find existing libproj installation: {}", err);
+        build_from_source()
+    })
+}
 
 #[cfg(feature = "nobuild")]
 fn main() {} // Skip the build script on docs.rs
@@ -19,28 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("feature flags specified source build");
         build_from_source()?
     } else {
-        pkg_config::Config::new()
-        .atleast_version(MINIMUM_PROJ_VERSION)
-        .probe("proj")
-        .and_then(|pk| {
-            eprintln!("found acceptable libproj already installed at: {:?}", pk.link_paths[0]);
-            if let Ok(val) = &env::var("_PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC") {
-                if val != "0" {
-                    panic!("for testing purposes: existing package was found, but should not have been");
-                }
-            }
-
-            // Tell cargo to tell rustc to link the system proj
-            // shared library.
-            println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
-            println!("cargo:rustc-link-lib=proj");
-
-            Ok(pk.include_paths[0].clone())
-        })
-        .or_else(|err| {
-            eprintln!("pkg-config unable to find existing libproj installation: {}", err);
-            build_from_source()
-        })?
+        try_vcpkg()?
     };
 
     // The bindgen::Builder is the main entry point


### PR DESCRIPTION
I added the support of [vcpkg](https://github.com/microsoft/vcpkg) libraries in proj-sys.
This allow to build proj-sys on windows with msvc without pkg-config.

To use vcpkg libraries on your rust program, you need:
- in **.cargo/config** file
```
[target.x86_64-pc-windows-msvc]
linker = "rust-lld.exe"
rustflags = ["-Ctarget-feature=+crt-static"]
```
- in **Cargo.toml** file
```
[package.metadata.vcpkg]
git = "https://github.com/microsoft/vcpkg"
rev = "96a1f9c" # PROJ version 7.2.1 - https://github.com/microsoft/vcpkg/search?q=proj4&type=commits
install = ["proj:x64-windows-static"]
```


To build, run
```
cargo install cargo-vcpkg
cargo vcpkg build
cargo build
```

I'm new to rust, I hope this isn't to ugly in my implementation.