### PR TITLE
Fix linker error when building proj-sys in debug mode with MSVC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## Unreleased
+- [Allow proj-sys to link to `proj_d.lib`. This prevents a linker error when building in debug mode with MSVC](https://github.com/georust/proj/pull/83)
+
 ## 0.22.0
 - Update PROJ to 7.2.1 via proj-sys 0.19.0
 

--- a/proj-sys/build.rs
+++ b/proj-sys/build.rs
@@ -100,7 +100,13 @@ fn build_from_source() -> Result<std::path::PathBuf, Box<dyn std::error::Error>>
     let proj = config.build();
     // Tell cargo to tell rustc to link libproj, and where to find it
     // libproj will be built in $OUT_DIR/lib
-    println!("cargo:rustc-link-lib=static=proj");
+    
+    //proj likes to create proj_d when configured as debug and on MSVC, so link to that one if it exists
+    if proj.join("lib").join("proj_d.lib").exists() {
+      println!("cargo:rustc-link-lib=static=proj_d");
+    } else {
+      println!("cargo:rustc-link-lib=static=proj");
+    }
     println!(
         "cargo:rustc-link-search=native={}",
         proj.join("lib").display()


### PR DESCRIPTION
The proj CMakeLists.txt contains instructions to add a `_d` suffix to the compiled library in certain situations:
https://github.com/OSGeo/PROJ/blob/e3d7e18f988230973ced5163fa2581b6671c8755/src/CMakeLists.txt#L86

Proj-sys does not expect this suffix and fails to find the library. This results in build failure.
This PR adds support for the suffixed library.