### PR TITLE
Impl drop for HandleData

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## Unreleased
+- Fix memory leak in network grid functionality
+
 ## 0.24.0
 - update to proj-sys 0.21.0
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -25,7 +25,6 @@ const MAX_RETRIES: u8 = 8;
 const RETRY_CODES: [u16; 4] = [429, 500, 502, 504];
 
 /// This struct is cast to `c_void`, then to `PROJ_NETWORK_HANDLE` so it can be passed around
-#[repr(C)]
 struct HandleData {
     request: reqwest::blocking::RequestBuilder,
     headers: reqwest::header::HeaderMap,

--- a/src/network.rs
+++ b/src/network.rs
@@ -168,7 +168,7 @@ unsafe fn _network_open(
     // RANGE header definition is "bytes=x-y"
     let hvalue = format!("bytes={}-{}", offset, end);
     // Create a new client that can be reused for subsequent queries
-    let clt = Client::builder().build();
+    let clt = Client::builder().build()?;
     let req = clt.request(Method::GET, &url);
     // this performs the initial byte read, presumably as an error check
     let initial = req.try_clone().ok_or(ProjError::RequestCloneError)?;

--- a/src/network.rs
+++ b/src/network.rs
@@ -207,11 +207,10 @@ pub(crate) unsafe extern "C" fn network_close(
     handle: *mut PROJ_NETWORK_HANDLE,
     _: *mut c_void,
 ) {
-    // Reconstitute the Handle data so it can be dropped
-    let hd = &*(handle as *const c_void as *mut HandleData);
-    // Reconstitute the header value returned by network_get_header_value,
-    // since libproj never explicitly returns it to us
-    let _ = *hd;
+    // Because we created the raw pointer from a Box, we have to re-constitute the Box
+    // This is the exact reverse order seen in _network_open
+    let void = handle as *mut c_void as *mut HandleData;
+    let _: Box<HandleData> = Box::from_raw(void);
 }
 
 /// Network callback: get header value

--- a/src/network.rs
+++ b/src/network.rs
@@ -168,7 +168,7 @@ unsafe fn _network_open(
     // RANGE header definition is "bytes=x-y"
     let hvalue = format!("bytes={}-{}", offset, end);
     // Create a new client that can be reused for subsequent queries
-    let clt = Client::builder().build()?;
+    let clt = Client::builder().build();
     let req = clt.request(Method::GET, &url);
     // this performs the initial byte read, presumably as an error check
     let initial = req.try_clone().ok_or(ProjError::RequestCloneError)?;
@@ -209,8 +209,8 @@ pub(crate) unsafe extern "C" fn network_close(
 ) {
     // Reconstitute the Handle data so it can be dropped
     let hd = &*(handle as *const c_void as *mut HandleData);
-    // Reconstitute and drop the header value returned by network_get_header_value,
-    // since PROJ never explicitly returns it to us
+    // Reconstitute the header value returned by network_get_header_value,
+    // since libproj never explicitly returns it to us
     let _ = *hd;
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -66,7 +66,8 @@ fn get_wait_time_exp(retrycount: i32) -> u64 {
 }
 
 /// Process CDN response: handle retries in case of server error, or early return for client errors
-fn error_handler<'a>(res: &'a mut Response, rb: RequestBuilder) -> Result<&'a Response, ProjError> {
+/// Successful retry data is stored into res
+fn error_handler(res: &mut Response, rb: RequestBuilder) -> Result<&Response, ProjError> {
     let mut status = res.status().as_u16();
     let mut retries = 0;
     // Check whether something went wrong on the server, or if it's an S3 retry code


### PR DESCRIPTION
This a draft PR to investigate the possibility of improving the safety of the `network` functionality.

ATM, this is just a move of the pointer-reconstitution logic into a `Drop` impl (This is safer than assuming a function will be called, although of course `drop()` isn't called on panic), but there will hopefully be more to come when I've done some more digging.

This also fixes some unnecessary mutability and borrows, and makes the struct we pass to libproj `repr c`.