### PR TITLE
Fix source build on aarch64/homebrew

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = ["proj-sys"]
 default = ["geo-types"]
 bundled_proj = [ "proj-sys/bundled_proj" ]
 pkg_config = [ "proj-sys/pkg_config" ]
-network = ["reqwest"]
+network = ["reqwest", "proj-sys/network"]
 
 [dev-dependencies]
 approx = "0.3"

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -24,6 +24,7 @@ nobuild = []
 bundled_proj = []
 # `pkg_config` feature is deprecated and does nothing
 pkg_config = []
+network = []
 
 [package.metadata.docs.rs]
 features = [ "nobuild" ] # This feature will be enabled during the docs.rs build


### PR DESCRIPTION
Slightly improves the situation at #57

On apple platforms, libtiff is not installed by the operating system. If
the user has it installed, likely it was installed by homebrew.

Previously, on x86, homebrew installed libs into /usr/lib which is in
the default search path, but since aarch64, homebrew has moved libs to
/opt/homebrew/lib.

So now we use pkg-config to find the library.

Potential problems:

 - Not everyone has pkg-config (e.g windows users, a few mac users)
 - Not everyone actually needs libtiff, only the network geotiff users,
   but we assume everyone needs it since most system installations
   include it.

Note that proj enables tiff support by defeault, provided libtiff is
found (using pkg-config? or something else?)


This is a draft because some tests are currently failing for me on aarch64. I'm looking into it now...

<details>
<summary>failing test output</summary>
<pre>
geos: Invalid latitude
geos: Invalid latitude
"proj=pipeline step proj=unitconvert xy_in=us-ft xy_out=m step inv proj=lcc lat_0=32.1666666666667 lon_0=-116.25 lat_1=33.8833333333333 lat_2=32.7833333333333 x_0=2000000.0001016 y_0=500000.0001016 ellps=GRS80 step proj=lcc lat_0=32.1666666666667 lon_0=-116.25 lat_1=33.8833333333333 lat_2=32.7833333333333 x_0=2000000 y_0=500000 ellps=GRS80"
proj_create: unrecognized format / unknown name

assert_relative_eq!(t.x(), 0.43633200013698786)

    left  = NaN
    right = 0.43633200013698786


thread 'proj::test::test_inverse_projection' panicked at 'assert_relative_eq!(t.x(), 0.43633200013698786)

    left  = NaN
    right = 0.43633200013698786

', src/proj.rs:1069:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:517:5
   1: std::panicking::begin_panic_fmt
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:460:5
   2: proj::proj::test::test_inverse_projection
             at ./src/proj.rs:1069:9
   3: proj::proj::test::test_inverse_projection::{{closure}}
             at ./src/proj.rs:1059:5
   4: core::ops::function::FnOnce::call_once
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


assert_relative_eq!(t.x(), 0.0023755864830313977)

    left  = NaN
    right = 0.0023755864830313977


thread 'proj::test::test_london_inverse' panicked at 'assert_relative_eq!(t.x(), 0.0023755864830313977)

    left  = NaN
    right = 0.0023755864830313977

', src/proj.rs:1086:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:517:5
   1: std::panicking::begin_panic_fmt
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:460:5
   2: proj::proj::test::test_london_inverse
             at ./src/proj.rs:1086:9
   3: proj::proj::test::test_london_inverse::{{closure}}
             at ./src/proj.rs:1074:5
   4: core::ops::function::FnOnce::call_once
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


assert_relative_eq!(t.x(), 500119.7035366755, epsilon = 1e-5)

    left  = NaN
    right = 500119.7035366755


thread 'proj::test::test_projection' panicked at 'assert_relative_eq!(t.x(), 500119.7035366755, epsilon = 1e-5)

    left  = NaN
    right = 500119.7035366755

', src/proj.rs:1054:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:517:5
   1: std::panicking::begin_panic_fmt
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:460:5
   2: proj::proj::test::test_projection
             at ./src/proj.rs:1054:9
   3: proj::proj::test::test_projection::{{closure}}
             at ./src/proj.rs:1044:5
   4: core::ops::function::FnOnce::call_once
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

thread 'proj::test::test_searchpath' panicked at 'assertion failed: `(left == right)`
  left: `"/Users/mkirk/src/georust/proj/target/debug/build/proj-sys-1e3a03028e94a7d6/out/share/proj"`,
 right: `"/foo"`', src/proj.rs:1016:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/panicking.rs:101:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/panicking.rs:140:5
   4: proj::proj::test::test_searchpath
             at ./src/proj.rs:1016:9
   5: proj::proj::test::test_searchpath::{{closure}}
             at ./src/proj.rs:1010:5
   6: core::ops::function::FnOnce::call_once
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
</pre>
</details>