### PR TITLE
Update `proj::Proj` constructors to return `Result` instead of `Option`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,5 +217,6 @@ pub use crate::proj::Coord;
 pub use crate::proj::Info;
 pub use crate::proj::Proj;
 pub use crate::proj::ProjBuilder;
+pub use crate::proj::ProjCreateError;
 pub use crate::proj::ProjError;
 pub use crate::proj::Projinfo;


### PR DESCRIPTION
Surface the underlying error from PROJ.