### PR TITLE
some failing tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container_image: ["georust/proj-ci:rust-1.52", "georust/proj-ci:rust-1.53"]
-        features: 
+        container_image:
+          - "georust/proj-ci:rust-1.52"
+          - "georust/proj-ci:rust-1.53"
+          - "georust/proj-ci:rust-1.54"
+          - "georust/proj-ci:rust-1.55"
+          - "georust/proj-ci:rust-1.56"
+          - "georust/proj-ci:rust-1.57"
+          - "georust/proj-ci:rust-1.58"
+        features:
           - ""
           - "--features network"
           - "--features bundled_proj"
@@ -74,22 +81,27 @@ jobs:
       matrix:
         include:
           - container:
-              image: georust/proj-ci:rust-1.53
-              env:
-                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
-            features: ""
-          - container:
               image: georust/proj-ci:rust-1.52
               env:
                 _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
             features: ""
           - container:
-              image: georust/proj-ci:rust-1.53
+              image: georust/proj-ci:rust-1.52
               env:
                 _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
             features: "--features bundled_proj"
           - container:
-              image: georust/proj-ci:rust-1.52
+              image: georust/proj-ci-without-system-proj:rust-1.52
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.53
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.53
               env:
                 _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
             features: "--features bundled_proj"
@@ -99,7 +111,77 @@ jobs:
                 _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
             features: ""
           - container:
-              image: georust/proj-ci-without-system-proj:rust-1.52
+              image: georust/proj-ci:rust-1.54
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.54
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: "--features bundled_proj"
+          - container:
+              image: georust/proj-ci-without-system-proj:rust-1.54
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.55
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.55
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: "--features bundled_proj"
+          - container:
+              image: georust/proj-ci-without-system-proj:rust-1.55
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.56
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.56
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: "--features bundled_proj"
+          - container:
+              image: georust/proj-ci-without-system-proj:rust-1.56
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.57
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.57
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: "--features bundled_proj"
+          - container:
+              image: georust/proj-ci-without-system-proj:rust-1.57
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.58
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 0
+            features: ""
+          - container:
+              image: georust/proj-ci:rust-1.58
+              env:
+                _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
+            features: "--features bundled_proj"
+          - container:
+              image: georust/proj-ci-without-system-proj:rust-1.58
               env:
                 _PROJ_SYS_TEST_EXPECT_BUILD_FROM_SRC: 1
             features: ""


### PR DESCRIPTION
We're seeing some failures in CI for https://github.com/georust/proj/pull/98 e.g.

https://github.com/georust/proj/runs/5014199807?check_suite_focus=true

> > Test failure look unrelated?
> 
> Indeed! I'm looking into that.

The failures seem eerily similar to the ones I found in: https://github.com/georust/proj/pull/97#issuecomment-994200364

I opened this PR just as a way to gather more data, to see if I could find a pattern.

CI Run from this branch: https://github.com/georust/proj/runs/5013682778?check_suite_focus=true

<ul>
<li> ✅ rust 1.52</li>
<li>⭕️ rust 1.53</li>
  <ul>
  <li><details><summary>❌ default features</summary> 
<pre>
failures:

---- proj::test::test_inverse_projection stdout ----
thread 'proj::test::test_inverse_projection' panicked at 'assert_relative_eq!(t.x(), 0.43633200013698786)

    left  = 0.43636512759931073
    right = 0.43633200013698786

', src/proj.rs:1069:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- proj::test::test_london_inverse stdout ----
thread 'proj::test::test_london_inverse' panicked at 'assert_relative_eq!(t.x(), 0.0023755864830313977)

    left  = 0.002407322568220306
    right = 0.0023755864830313977
', src/proj.rs:1086:9

---- proj::test::test_projection stdout ----
thread 'proj::test::test_projection' panicked at 'assert_relative_eq!(t.x(), 500119.7035366755, epsilon = 1e-5)
    left  = 499972.70746607287
    right = 500119.7035366755

', src/proj.rs:1054:9

failures:
    proj::test::test_inverse_projection
    proj::test::test_london_inverse
    proj::test::test_projection
</pre>
</li>
<li><details><summary>❌ --features=network</summary>
<pre>
failures:

---- proj::test::test_inverse_projection stdout ----
thread 'proj::test::test_inverse_projection' panicked at 'assert_relative_eq!(t.x(), 0.43633200013698786)

    left  = 0.43636512759931073
    right = 0.43633200013698786

', src/proj.rs:1069:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- proj::test::test_london_inverse stdout ----
thread 'proj::test::test_london_inverse' panicked at 'assert_relative_eq!(t.x(), 0.0023755864830313977)

    left  = 0.002407322568220306
    right = 0.0023755864830313977

', src/proj.rs:1086:9

---- proj::test::test_projection stdout ----
thread 'proj::test::test_projection' panicked at 'assert_relative_eq!(t.x(), 500119.7035366755, epsilon = 1e-5)

    left  = 499972.70746607287
    right = 500119.7035366755

', src/proj.rs:1054:9


failures:
    proj::test::test_inverse_projection
    proj::test::test_london_inverse
    proj::test::test_projection
</pre></details></li>
<li>✅ --features=bundled_proj</li>
<li><details><summary>❌ --no-default-features</summary>
<pre>
failures:

---- proj::test::test_inverse_projection stdout ----
thread 'proj::test::test_inverse_projection' panicked at 'assert_relative_eq!(t.x(), 0.43633200013698786)

    left  = 0.43636512759931073
    right = 0.43633200013698786

', src/proj.rs:1069:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- proj::test::test_london_inverse stdout ----
thread 'proj::test::test_london_inverse' panicked at 'assert_relative_eq!(t.x(), 0.0023755864830313977)

    left  = 0.002407322568220306
    right = 0.0023755864830313977

', src/proj.rs:1086:9

---- proj::test::test_projection stdout ----
thread 'proj::test::test_projection' panicked at 'assert_relative_eq!(t.x(), 500119.7035366755, epsilon = 1e-5)

    left  = 499972.70746607287
    right = 500119.7035366755

', src/proj.rs:1054:9


failures:
    proj::test::test_inverse_projection
error: test failed, to rerun pass '--lib'
    proj::test::test_london_inverse
    proj::test::test_projection

test result: FAILED. 12 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.33s
</pre>
</details></li>
<li>✅ --features=network bundled_proj</li>
<li><details><summary>❌ --features=network geo-types</summary>
<pre>
failures:

---- proj::test::test_inverse_projection stdout ----
thread 'proj::test::test_inverse_projection' panicked at 'assert_relative_eq!(t.x(), 0.43633200013698786)

    left  = 0.43636512759931073
    right = 0.43633200013698786

', src/proj.rs:1069:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- proj::test::test_london_inverse stdout ----
thread 'proj::test::test_london_inverse' panicked at 'assert_relative_eq!(t.x(), 0.0023755864830313977)

    left  = 0.002407322568220306
    right = 0.0023755864830313977

', src/proj.rs:1086:9

---- proj::test::test_projection stdout ----
thread 'proj::test::test_projection' panicked at 'assert_relative_eq!(t.x(), 500119.7035366755, epsilon = 1e-5)

    left  = 499972.70746607287
    right = 500119.7035366755

', src/proj.rs:1054:9


failures:
    proj::test::test_inverse_projection
    proj::test::test_london_inverse
    proj::test::test_projection

test result: FAILED. 13 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.34s
</pre>
</details>
</li>
<li>✅ --features=bundled_proj geo-types</li>
<li>✅ --features=network bundled_proj geo-types</li>
</ul>
</li>
<li>✅ rust 1.54</li>
<li>✅ rust 1.55</li>
<li>✅ rust 1.56</li>
<li>✅ rust 1.57</li>
<li>✅ rust 1.58</li>
</ul>
