### PR TITLE
proj 0.25.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
-## Unreleased
+## 0.25.1
+
+- Fix intermittently wrong results due to memory initialization error.
+  - <https://github.com/georust/proj/pull/104>
 
 ## 0.25.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.25.0"
+version = "0.25.1"
 authors = [
     "The Georust Developers <mods@georust.org>"
 ]


### PR DESCRIPTION
Just a patch bump for @lnicola's bug fix.

The fix was entirely within proj, so there's no need for a proj-sys release.