### PR TITLE
Add `Default` trait constraint to CoordinateType

### DIFF
--- a/src/proj.rs
+++ b/src/proj.rs
@@ -27,8 +27,9 @@ use std::mem::MaybeUninit;
 use std::path::Path;
 use thiserror::Error;
 
-pub trait CoordinateType: Float + Copy + PartialOrd + Debug {}
-impl<T: Float + Copy + PartialOrd + Debug> CoordinateType for T {}
+/// Base numeric type. This should match CoordFloat trait in the geo-types crate.
+pub trait CoordinateType: Float + Copy + PartialOrd + Debug + Default {}
+impl<T: Float + Copy + PartialOrd + Debug + Default> CoordinateType for T {}
 
 /// An error number returned from a PROJ call.
 pub(crate) struct Errno(pub libc::c_int);


### PR DESCRIPTION
This is an alternative, simpler take on https://github.com/georust/proj/pull/110

Adding default constraint allows https://github.com/georust/geo/pull/751