### PR TITLE
Upgrade dependencies except "approx"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2018"
 
 [dependencies]
 proj-sys = { version = "0.22.0", path = "proj-sys" }
-geo-types = { version = "0.7", optional = true }
-libc = "0.2.62"
-num-traits = "0.2.8"
-thiserror = "1.0.4"
-reqwest = { version = "0.11.0", optional = true, default-features = false, features = ["blocking", "rustls-tls"] }
+geo-types = { version = "0.7.3", optional = true }
+libc = "0.2.119"
+num-traits = "0.2.14"
+thiserror = "1.0.30"
+reqwest = { version = "0.11.9", optional = true, default-features = false, features = ["blocking", "rustls-tls"] }
 
 [workspace]
 members = ["proj-sys"]
@@ -30,8 +30,9 @@ pkg_config = [ "proj-sys/pkg_config" ]
 network = ["reqwest", "proj-sys/network"]
 
 [dev-dependencies]
+# approx version must match the one used in geo-types
 approx = "0.4"
-geo-types = { version = "0.7", features = ["approx"] }
+geo-types = { version = "0.7.3", features = ["approx"] }
 
 [package.metadata.docs.rs]
 features = [ "proj-sys/nobuild", "network", "geo-types" ]

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -13,11 +13,11 @@ links = "proj"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.59.1"
-pkg-config = "0.3.19"
-cmake = "0.1"
-flate2 = "1.0.14"
-tar = "0.4.26"
+bindgen = "0.59.2"
+pkg-config = "0.3.24"
+cmake = "0.1.48"
+flate2 = "1.0.22"
+tar = "0.4.38"
 
 [features]
 nobuild = []


### PR DESCRIPTION
Upgrade all proj-sys and proj dependency versions to the latest. For consistency all versions are fully-specified. The only exception is the [approx](https://crates.io/crates/approx) lib because the trait is implemented upstream in `geo-types`. Perhaps if we change geo-types to use `approx = "*"`, it could work?

It is fairly easy to upgrade them now using [cargo upgrade](https://lib.rs/crates/cargo-edit). I usually run it in offline mode due to an [issue](https://github.com/killercup/cargo-edit/issues/515#issuecomment-996931030)

```
cargo update && cargo upgrade --offline --workspace
```