### PR TITLE
document the usage of Transform for types in geo-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ If you've enabled the `geo-types` feature, you can skip allocating an intermedia
 and pass the [`geo-types`](https://crates.io/crates/geo-types) directly.
 
 ```rust
-# use approx::assert_relative_eq;
+use approx::assert_relative_eq;
 use proj::Proj;
 use geo_types::Point;
 
@@ -211,6 +211,33 @@ let result = nad_ft_to_m.convert(my_point).unwrap();
 
 assert_relative_eq!(result.x(), 1450880.2910605003f64);
 assert_relative_eq!(result.y(), 1141263.0111604529f64);
+```
+
+You can also transform entire geometries from `geo-types` by using the
+`Transform` trait.
+
+```rust
+use proj::{Proj, Transform};
+use geo_types::{Coordinate, line_string};
+
+let line = line_string![
+    (x: -116.590457069172_f64, y: 32.55730630167689),
+    (x: -116.590411068973, y: 32.55714830169309),
+];
+let proj = Proj::new_known_crs("EPSG:4326", "EPSG:6366", None).unwrap();
+
+// create a new line with a different projection
+let new_line = line.transformed(&proj).unwrap();
+
+assert_eq!(new_line[0], Coordinate { x: 538447.8454476658, y: 3602285.563945497, });
+assert_eq!(new_line[1], Coordinate { x: 538452.2313532799, y: 3602268.065714932, });
+
+// or transform the original in-place
+let mut line = line;
+line.transform(&proj).unwrap();
+
+assert_eq!(line[0], Coordinate { x: 538447.8454476658, y: 3602285.563945497, });
+assert_eq!(line[1], Coordinate { x: 538452.2313532799, y: 3602268.065714932, });
 ```
 
 License: MIT/Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,33 @@ let result = nad_ft_to_m.convert(my_point).unwrap();
 assert_relative_eq!(result.x(), 1450880.29, epsilon=1e-2);
 assert_relative_eq!(result.y(), 1141263.01, epsilon=1e-2);
 ```
+
+You can also transform entire geometries from `geo-types` by using the
+`Transform` trait.
+
+```
+use proj::{Proj, Transform};
+use geo_types::{Coordinate, line_string};
+
+let line = line_string![
+    (x: -116.590457069172_f64, y: 32.55730630167689),
+    (x: -116.590411068973, y: 32.55714830169309),
+];
+let proj = Proj::new_known_crs("EPSG:4326", "EPSG:6366", None).unwrap();
+
+// create a new line with a different projection
+let new_line = line.transformed(&proj).unwrap();
+
+assert_eq!(new_line[0], Coordinate { x: 538447.8454476658, y: 3602285.563945497, });
+assert_eq!(new_line[1], Coordinate { x: 538452.2313532799, y: 3602268.065714932, });
+
+// or transform the original in-place
+let mut line = line;
+line.transform(&proj).unwrap();
+
+assert_eq!(line[0], Coordinate { x: 538447.8454476658, y: 3602285.563945497, });
+assert_eq!(line[1], Coordinate { x: 538452.2313532799, y: 3602268.065714932, });
+```
 "##
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,7 @@ You can also transform entire geometries from `geo-types` by using the
 `Transform` trait.
 
 ```
+# use approx::assert_relative_eq;
 use proj::{Proj, Transform};
 use geo_types::{Coordinate, line_string};
 
@@ -212,15 +213,15 @@ let proj = Proj::new_known_crs("EPSG:4326", "EPSG:6366", None).unwrap();
 // create a new line with a different projection
 let new_line = line.transformed(&proj).unwrap();
 
-assert_eq!(new_line[0], Coordinate { x: 538447.8454476658, y: 3602285.563945497, });
-assert_eq!(new_line[1], Coordinate { x: 538452.2313532799, y: 3602268.065714932, });
+assert_relative_eq!(new_line[0], Coordinate { x: 538447.8454476658, y: 3602285.563945497, });
+assert_relative_eq!(new_line[1], Coordinate { x: 538452.2313532799, y: 3602268.065714932, });
 
 // or transform the original in-place
 let mut line = line;
 line.transform(&proj).unwrap();
 
-assert_eq!(line[0], Coordinate { x: 538447.8454476658, y: 3602285.563945497, });
-assert_eq!(line[1], Coordinate { x: 538452.2313532799, y: 3602268.065714932, });
+assert_relative_eq!(line[0], Coordinate { x: 538447.8454476658, y: 3602285.563945497, });
+assert_relative_eq!(line[1], Coordinate { x: 538452.2313532799, y: 3602268.065714932, });
 ```
 "##
 )]


### PR DESCRIPTION
Hi folks!

Great work with this bindings and the whole georust ecosystem.

In this PR I propose to add to both the readme and the lib.rs docstring a comment on how to transform structures from `geo-types`. It took me half an hour and digging into the issues to learn that was possible and how to do it, so not ideal. I would like to save someone the research time so they can focus on using this great project!

✌️