### PR TITLE
Prepare for 0.26.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.26.0
+
+- Update to proj 9
+  - <https://github.com/georust/proj/pull/119>
+
 ## 0.25.2
 
 - Introduce `Transform` trait, add implementations for `geo-types`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.25.2"
+version = "0.26.0"
 authors = [
     "The Georust Developers <mods@georust.org>"
 ]


### PR DESCRIPTION
Anything else we should be waiting for before the 0.26.0 release?

@nyurik mentioned that releasing this makes some things simpler for them: https://github.com/georust/geo/pull/798#issuecomment-1100922099

