### PR TITLE
Idiomatic renaming of entities from libproj

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased
-- Make `PjInfo` struct public
+- Inline the functionality of the legacy `Info` trait directly into `Proj`/`ProjBuilder` and remove the `Info` trait.
+- Make `PjInfo` struct public, and rename it to `Info`
   - <https://github.com/georust/proj/pull/133>
 - Actually return an error if a definition can't be retrieved
   - <https://github.com/georust/proj/pull/132>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,4 +249,3 @@ pub use crate::proj::Proj;
 pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjCreateError;
 pub use crate::proj::ProjError;
-pub use crate::proj::Projinfo;

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -227,18 +227,18 @@ fn transform_epsg(
     })
 }
 
-/// Read-only utility methods for providing information about the current PROJ instance
-pub trait Info {
+///// Read-only utility methods for providing information about the current PROJ instance
+pub trait HasInfo {
     #[doc(hidden)]
     fn ctx(&self) -> *mut PJ_CONTEXT;
 
     /// Return [Information](https://proj.org/development/reference/datatypes.html#c.PJ_INFO) about the current PROJ context
     /// # Safety
     /// This method contains unsafe code.
-    fn info(&self) -> Result<Projinfo, ProjError> {
+    fn info(&self) -> Result<Info, ProjError> {
         unsafe {
             let pinfo: PJ_INFO = proj_info();
-            Ok(Projinfo {
+            Ok(Info {
                 major: pinfo.major,
                 minor: pinfo.minor,
                 patch: pinfo.patch,
@@ -267,7 +267,7 @@ pub trait Info {
     }
 }
 
-impl Info for ProjBuilder {
+impl HasInfo for ProjBuilder {
     #[doc(hidden)]
     fn ctx(&self) -> *mut PJ_CONTEXT {
         self.ctx
@@ -354,7 +354,7 @@ impl ProjBuilder {
     }
 }
 
-impl Info for Proj {
+impl HasInfo for Proj {
     #[doc(hidden)]
     fn ctx(&self) -> *mut PJ_CONTEXT {
         self.ctx
@@ -368,7 +368,7 @@ enum Transformation {
 
 /// [Information](https://proj.org/development/reference/datatypes.html#c.PJ_INFO) about PROJ
 #[derive(Clone, Debug)]
-pub struct Projinfo {
+pub struct Info {
     pub major: i32,
     pub minor: i32,
     pub patch: i32,
@@ -671,7 +671,7 @@ impl Proj {
         }
     }
 
-    fn pj_info(&self) -> PjInfo {
+    fn proj_info(&self) -> ProjInfo {
         unsafe {
             let pj_info = proj_pj_info(self.c_proj);
             let id = if pj_info.id.is_null() {
@@ -690,7 +690,7 @@ impl Proj {
                 Some(_string(pj_info.definition).expect("PROJ built an invalid string"))
             };
             let has_inverse = pj_info.has_inverse == 1;
-            PjInfo {
+            ProjInfo {
                 id,
                 description,
                 definition,
@@ -705,7 +705,7 @@ impl Proj {
     /// # Safety
     /// This method contains unsafe code.
     pub fn def(&self) -> Result<String, ProjError> {
-        self.pj_info().definition.ok_or(ProjError::Definition)
+        self.proj_info().definition.ok_or(ProjError::Definition)
     }
 
     /// Project geodetic coordinates (in radians) into the projection specified by `definition`
@@ -1032,7 +1032,7 @@ pub struct ProjInfo {
 
 impl fmt::Debug for Proj {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let pj_info = self.pj_info();
+        let pj_info = self.proj_info();
         f.debug_struct("Proj")
             .field("id", &pj_info.id)
             .field("description", &pj_info.description)


### PR DESCRIPTION
Note this PR targets your PR #133 @urschrei, and is a follow-up to this comment specifically: https://github.com/georust/proj/pull/133#discussion_r896109068

This proposal is an admittedly baroque dance, but I think it has some benefits...

If we were to just do the [Conventional re-naming for libproj entities](https://github.com/georust/proj/commit/ac63a9ecea3f3f4ce7c3bafea4fcec1a34432f0d) commit, legacy users of the `Info` trait would see an error like:

```
   warning: unused import: `Info`
     --> src/main.rs:1:18
      |
    1 | use proj::{Proj, Info};
      |                  ^^^^
      |
      = note: `#[warn(unused_imports)]` on by default
    
    error[E0599]: no method named `network_enabled` found for struct `Proj` in the current scope
       --> src/main.rs:5:19
        |
    5   |     assert!(!proj.network_enabled());
        |                   ^^^^^^^^^^^^^^^ method not found in `Proj`
        |
       ::: /Users/mkirk/.cargo/git/checkouts/proj-89eb02e1b32feb8b/5516e1f/src/proj.rs:256:8
        |
    256 |     fn network_enabled(&self) -> bool {
        |        --------------- the method is available for `Proj` here
        |
        = help: items from traits can only be used if the trait is in scope
    help: the following trait is implemented but not in scope; perhaps add a `use` for it:
        |
    1   | use proj::proj::HasInfo;
        |
```

With the additional inclusion of 6992649ac58ecd63d8744b33999cdfb5ce9bd448 users will not error, and just see a warning:
```
 warning: unused import: `Info`
     --> src/main.rs:1:18
      |
    1 | use proj::{Proj, Info};
      |                  ^^^^
      |
      = note: `#[warn(unused_imports)]` on by default
```

It's still potentially confusing to remove a trait and replace it with a struct of the same name, but I don't think any builds should break and it leaves us with idiomatic naming.