### PR TITLE
make `fn proj_info` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,3 +249,4 @@ pub use crate::proj::Proj;
 pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjCreateError;
 pub use crate::proj::ProjError;
+pub use crate::proj::ProjInfo;

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1030,11 +1030,11 @@ impl convert::TryFrom<(&str, &str)> for Proj {
 /// [PROJ reference documentation](https://proj.org/development/reference/datatypes.html?highlight=has_inverse#c.PJ_PROJ_INFO)
 #[derive(Clone, Debug)]
 pub struct ProjInfo {
-    id: Option<String>,
-    description: Option<String>,
-    definition: Option<String>,
-    has_inverse: bool,
-    accuracy: f64,
+    pub id: Option<String>,
+    pub description: Option<String>,
+    pub definition: Option<String>,
+    pub has_inverse: bool,
+    pub accuracy: f64,
 }
 
 impl fmt::Debug for Proj {

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -233,7 +233,13 @@ macro_rules! define_info_methods {
             self.ctx
         }
 
-        /// Return [Information](https://proj.org/development/reference/datatypes.html#c.PJ_INFO) about the current PROJ context
+        /// Return information about the current instace of the PROJ libary.
+        ///
+        /// See: <https://proj.org/development/reference/datatypes.html#c.PJ_INFO>
+        ///
+        /// If instead you are looking for information about a specific transformation, see
+        /// [`Proj::proj_info`].
+        ///
         /// # Safety
         /// This method contains unsafe code.
         pub fn info(&self) -> Result<Info, ProjError> {
@@ -663,7 +669,16 @@ impl Proj {
         }
     }
 
-    fn proj_info(&self) -> ProjInfo {
+    /// Get information about a specific transformation object.
+    ///
+    /// See <https://proj.org/development/reference/functions.html#c.proj_pj_info>
+    ///
+    /// If instead you are looking for information about the proj installation, see
+    /// [`Proj::info`].
+    ///
+    /// # Safety
+    /// This method contains unsafe code.
+    pub fn proj_info(&self) -> ProjInfo {
         unsafe {
             let pj_info = proj_pj_info(self.c_proj);
             let id = if pj_info.id.is_null() {


### PR DESCRIPTION
Previously we'd made the struct public, but we also probably want to make it possible to *get* the struct (`pub fn proj_info`) and we also probably want to make the fields public, otherwise people can't do much with it.

I also tweaked the docs a bit to better disambiguate between `info` and `proj_info`.
