### PR TITLE
match approx spec to geo-types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+- Bump `approx` dev dependency to match `geo-types`. This doesn't affect
+  downstream users, only those building the proj crate for development.
+
 ## 0.27.0
 - Inline the functionality of the legacy `Info` trait directly into `Proj`/`ProjBuilder` and remove the `Info` trait.
   - BREAKING: Getting information about the version of libproj installed was renamed from proj.info() to proj.lib_info()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ network = ["reqwest", "proj-sys/network"]
 
 [dev-dependencies]
 # approx version must match the one used in geo-types
-approx = "0.4"
+approx = ">= 0.4.0, < 0.6.0"
 geo-types = { version = "0.7.3", features = ["approx"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
We bumped the approx dep in geo-types a while back, we should do the
same here.
