### PR TITLE
Use SPDX license expression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Bump `approx` dev dependency to match `geo-types`. This doesn't affect
   downstream users, only those building the proj crate for development.
+- Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
+  -  <https://github.com/georust/proj/pull/146>
 
 ## 0.27.0
 - Inline the functionality of the legacy `Info` trait directly into `Proj`/`ProjBuilder` and remove the `Info` trait.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 repository = "https://github.com/georust/proj"
 documentation = "https://docs.rs/proj/"
 keywords = ["proj", "projection", "osgeo", "geo"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2018"
 

--- a/proj-sys/CHANGES.md
+++ b/proj-sys/CHANGES.md
@@ -5,6 +5,8 @@
       - <https://github.com/georust/proj/pull/143>
 - Update to PROJ 9.1.0
 - Update MSRV to 1.58.0
+- Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
+  -  <https://github.com/georust/proj/pull/146>
 
 # 0.23.1
 

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.23.1"
 readme = "README.md"
 authors = ["The Georust developers <mods@georust.org>"]
 keywords = ["proj", "projection", "osgeo", "geo", "geospatial"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 links = "proj"
 


### PR DESCRIPTION
Uses a SPDX license expression as recommended by [Cargo](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields).

This enables e.g. parsing via the [CycloneDX Rust Cargo Plugin](https://github.com/CycloneDX/cyclonedx-rust-cargo).