### PR TITLE
Add pointer lints, run clippy, apply fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 - Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
   -  <https://github.com/georust/proj/pull/146>
 
+- Run clippy and apply fixes
+
 ## 0.27.0
 - Inline the functionality of the legacy `Info` trait directly into `Proj`/`ProjBuilder` and remove the `Info` trait.
   - BREAKING: Getting information about the version of libproj installed was renamed from proj.info() to proj.lib_info()

--- a/proj-sys/build.rs
+++ b/proj-sys/build.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             pk.include_paths[0].clone()
         })
         .or_else(|err| {
-            eprintln!("pkg-config unable to find existing libproj installation: {}", err);
+            eprintln!("pkg-config unable to find existing libproj installation: {err}");
             build_from_source()
         })?
     };
@@ -153,7 +153,7 @@ fn build_from_source() -> Result<std::path::PathBuf, Box<dyn std::error::Error>>
                 // pkg-config might not even be installed. Let's try to stumble forward
                 // to see if the build succeeds regardless, e.g. if libtiff is installed
                 // in some default search path.
-                eprintln!("Failed to find libtiff with pkg-config: {}", err);
+                eprintln!("Failed to find libtiff with pkg-config: {err}");
             }
         }
         println!("cargo:rustc-link-lib=dylib=tiff");

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -343,7 +343,7 @@ impl ProjBuilder {
     /// This method contains unsafe code.
     pub fn grid_cache_enable(&mut self, enable: bool) {
         let enable = if enable { 1 } else { 0 };
-        let _ = unsafe { proj_grid_cache_set_enable(self.ctx(), enable) };
+        unsafe { proj_grid_cache_set_enable(self.ctx(), enable) };
     }
 
     /// Set the URL endpoint to query for remote grids
@@ -1162,7 +1162,7 @@ mod test {
     fn test_debug() {
         let wgs84 = "+proj=longlat +datum=WGS84 +no_defs";
         let proj = Proj::new(wgs84).unwrap();
-        let debug_string = format!("{:?}", proj);
+        let debug_string = format!("{proj:?}");
         assert_eq!(
             "Proj { id: Some(\"longlat\"), description: Some(\"PROJ-based coordinate operation\"), definition: Some(\"proj=longlat datum=WGS84 no_defs ellps=WGS84 towgs84=0,0,0\"), has_inverse: true, accuracy: -1.0 }",
             debug_string
@@ -1174,7 +1174,7 @@ mod test {
     // This failure is a bug in libproj
     fn test_searchpath() {
         let mut tf = ProjBuilder::new();
-        tf.set_search_paths(&"/foo").unwrap();
+        tf.set_search_paths("/foo").unwrap();
         let ipath = tf.lib_info().unwrap().searchpath;
         let pathsep = if cfg!(windows) { ";" } else { ":" };
         let individual: Vec<&str> = ipath.split(pathsep).collect();


### PR DESCRIPTION
We're now denying some optional lints related to unsafe handling of raw pointers