### PR TITLE
Add `transform_bounds` to wrap `proj_trans_bounds`

### DIFF
--- a/src/proj.rs
+++ b/src/proj.rs
@@ -924,6 +924,10 @@ impl Proj {
     /// and transformation steps, allowing for extremely complex operations ([`new`](#method.new))
     /// 2. Using EPSG codes or `PROJ` strings to define input and output CRS ([`new_known_crs`](#method.new_known_crs))
     ///
+    /// The `densify_pts` parameter describes the number of points to add to each edge to account
+    /// for nonlinear edges produced by the transform process. Large numbers will produce worse
+    /// performance.
+    ///
     /// The following example converts from NAD83 US Survey Feet (EPSG 2230) to NAD83 Metres (EPSG 26946)
     ///
     /// ```rust

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -426,7 +426,6 @@ impl ProjBuilder {
     ///
     ///```rust
     /// # use approx::assert_relative_eq;
-    /// extern crate proj;
     /// use proj::{Proj, Coord};
     ///
     /// let from = "EPSG:2230";
@@ -787,7 +786,6 @@ impl Proj {
     ///
     /// ```rust
     /// # use approx::assert_relative_eq;
-    /// extern crate proj;
     /// use proj::{Proj, Coord};
     ///
     /// let from = "EPSG:2230";
@@ -930,7 +928,6 @@ impl Proj {
     ///
     /// ```rust
     /// # use approx::assert_relative_eq;
-    /// extern crate proj;
     /// use proj::{Proj, Coord};
     ///
     /// let from = "EPSG:2230";


### PR DESCRIPTION
This adds a wrapper of `transform_bounds`, similar to pyproj's `transform_bounds` ([docs](https://pyproj4.github.io/pyproj/stable/api/proj.html#pyproj.Proj.transform_bounds), [code](https://github.com/pyproj4/pyproj/blob/79a8602a2b0b50bf72c072b5a31317570bbdf550/pyproj/_transformer.pyx#L935-L1018)). 

This also adds a quick doctest, which is derived from one of the above doctests, but which I ran in pyproj to get the output data to compare against.
```py
from pyproj import CRS, Transformer
start = CRS("EPSG:2230")
end = CRS("EPSG:26946")
transformer = Transformer.from_crs(start, end, always_xy=True)
transformer.transform_bounds(4760096.421921, 3744293.729449, 4760196.421921, 3744393.729449)
# (1450880.2910605017,
#  1141263.0111604768,
#  1450910.7711214642,
#  1141293.4912214405)
```

Questions:

- Should this handle radians/degrees like pyproj is doing?