### PR TITLE
Fix build script on Windows with MYSYS2

### DIFF
--- a/proj-sys/build.rs
+++ b/proj-sys/build.rs
@@ -163,6 +163,12 @@ fn build_from_source() -> Result<std::path::PathBuf, Box<dyn std::error::Error>>
         println!("cargo:rustc-link-lib=dylib=stdc++");
     } else if cfg!(target_os = "macos") {
         println!("cargo:rustc-link-lib=dylib=c++");
+    } else if cfg!(target_os = "windows") {
+        if cfg!(target_env = "gnu") {
+            println!("cargo:rustc-link-lib=dylib=stdc++");
+        } else {
+            println!("cargo:warning=proj-sys: Not configuring an explicit C++ standard library on this target.");
+        }
     } else {
         println!("cargo:warning=proj-sys: Not configuring an explicit C++ standard library on this target.");
     }


### PR DESCRIPTION
Fixes the build on Windows when using [MYSYS2](https://www.msys2.org/), explicitly using `libstdc++`.
In order to build with mysys2, the required libraries are (prefix: `mingw-w64-ucrt-x86_64-`):
* clang
* cmake
* libtiff
* make
* rust
* sqlite3