### PR TITLE
Add a failing test to check that merge queues work

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,3 +253,12 @@ pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjCreateError;
 pub use crate::proj::ProjError;
 pub use crate::proj::ProjInfo;
+
+#[cfg(test)]
+mod tests{
+    #[test]
+    fn fail() {
+        // testing that our CI won't merge this
+        panic!("this test fails")
+    }
+}


### PR DESCRIPTION
Hopefully CI won't merge this.

This time I specified that the "ci result" task must complete before merging. Let's see if it works. 

If this hangs without merging, we still might need #170.

<img width="827" alt="Screenshot 2023-07-28 at 09 58 09" src="https://github.com/georust/proj/assets/217057/ef77aaf5-d07f-404f-9945-382e4652d22b">
