### PR TITLE
 Add a failing test to check that merge queues work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
   # Ref: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   #
   # ALL THE SUBSEQUENT JOBS NEED THEIR key ADDED TO THE `needs` SECTION OF THIS JOB!
-  ci-result:
+  ci-success:
     name: ci result
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ success() }}
     needs:
       - proj-ubuntu
       - proj-sys-ubuntu
@@ -27,10 +27,19 @@ jobs:
       - proj-sys-macos
     steps:
       - name: Mark the job as a success
-        if: ${{ success() }}
         run: exit 0
+
+  ci-failure:
+    name: ci result
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    needs:
+      - proj-ubuntu
+      - proj-sys-ubuntu
+      - proj-macos
+      - proj-sys-macos
+    steps:
       - name: Mark the job as a failure
-        if: ${{ failure() }}
         run: exit 1
 
   proj-ubuntu:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 name: proj ci
 jobs:
   # The `ci-result` job doesn't actually test anything - it just aggregates the
-  # overall build status for bors, otherwise our bors.toml would need an entry
+  # overall build status, otherwise the merge queue would need an entry
   # for each individual job produced by the job-matrix.
   #
   # Ref: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
@@ -19,6 +19,7 @@ jobs:
   ci-result:
     name: ci result
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     needs:
       - proj-ubuntu
       - proj-sys-ubuntu
@@ -26,10 +27,10 @@ jobs:
       - proj-sys-macos
     steps:
       - name: Mark the job as a success
-        if: success()
+        if: ${{ success() }}
         run: exit 0
       - name: Mark the job as a failure
-        if: "!success()"
+        if: ${{ failure() }}
         run: exit 1
 
   proj-ubuntu:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,12 +253,3 @@ pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjCreateError;
 pub use crate::proj::ProjError;
 pub use crate::proj::ProjInfo;
-
-#[cfg(test)]
-mod tests{
-    #[test]
-    fn fail() {
-        // testing that our CI won't merge this
-        panic!("this test fails")
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,3 +253,12 @@ pub use crate::proj::ProjBuilder;
 pub use crate::proj::ProjCreateError;
 pub use crate::proj::ProjError;
 pub use crate::proj::ProjInfo;
+
+#[cfg(test)]
+mod tests{
+    #[test]
+    fn fail() {
+        // testing that our CI won't merge this
+        panic!("this test fails")
+    }
+}


### PR DESCRIPTION
Hopefully CI won't merge this. If it does, I'll revert it right away.

I'm starting to suspect that the issue is with our aggregate "ci status" job. Previously the ci status job was skipped if one of it's dependents failed. It seems like maybe "skipped" doesn't count as "failed"?
