### PR TITLE
Add bundling support on windows

### DIFF
--- a/proj-sys/build.rs
+++ b/proj-sys/build.rs
@@ -121,6 +121,15 @@ fn build_from_source() -> Result<std::path::PathBuf, Box<dyn std::error::Error>>
         config.define("ENABLE_TIFF", "OFF");
     }
 
+    if cfg!(target_env = "msvc") {
+        // rust links the release MVSC runtime
+        // also for debug builds. If we let
+        // cmake choose debug/release builds
+        // based on the underlying cargo build
+        // version that results in linker errors
+        config.profile("Release");
+    }
+
     let proj = config.build();
     // Tell cargo to tell rustc to link libproj, and where to find it
     // libproj will be built in $OUT_DIR/lib


### PR DESCRIPTION
We need to always build release builds there (to prevent linker errors due to mixing up debug and release runtimes) and we need an additional flag to prevent the static library to expect some proj.dll file to exist