### PR TITLE
Allow creating a Proj from an owned String

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ use proj::Proj;
 
 let from = "EPSG:2230";
 let to = "EPSG:26946";
-let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+let ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
 let result = ft_to_m
     .convert((4760096.421921f64, 3744293.729449f64))
     .unwrap();
@@ -183,7 +183,7 @@ let donut_shop = MyPointOfInterest { lat: 34.095620, lon: -118.283555 };
 
 let from = "EPSG:4326";
 let to = "EPSG:3309";
-let proj = Proj::new_known_crs(&from, &to, None).unwrap();
+let proj = Proj::new_known_crs(from, to, None).unwrap();
 
 let result = proj.convert(donut_shop).unwrap();
 
@@ -205,7 +205,7 @@ let my_point = Point::new(4760096.421921f64, 3744293.729449f64);
 
 let from = "EPSG:2230";
 let to = "EPSG:26946";
-let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+let nad_ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
 
 let result = nad_ft_to_m.convert(my_point).unwrap();
 

--- a/src/geo_types.rs
+++ b/src/geo_types.rs
@@ -9,7 +9,7 @@ use geo_types::{coord, Geometry};
 ///
 /// let from = "EPSG:2230";
 /// let to = "EPSG:26946";
-/// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+/// let nad_ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
 /// let result = nad_ft_to_m
 ///     .convert(coord! { x: 4760096.421921f64, y: 3744293.729449f64 })
 ///     .unwrap();
@@ -36,7 +36,7 @@ impl<T: crate::proj::CoordinateType> crate::Coord<T> for geo_types::Coord<T> {
 ///
 /// let from = "EPSG:2230";
 /// let to = "EPSG:26946";
-/// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+/// let nad_ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
 /// let result = nad_ft_to_m
 ///     .convert(Point::new(4760096.421921f64, 3744293.729449f64))
 ///     .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! let from = "EPSG:2230";
 //! let to = "EPSG:26946";
-//! let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+//! let ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
 //! let result = ft_to_m
 //!     .convert((4760096.421921f64, 3744293.729449f64))
 //!     .unwrap();
@@ -167,7 +167,7 @@
 //!
 //! let from = "EPSG:4326";
 //! let to = "EPSG:3309";
-//! let proj = Proj::new_known_crs(&from, &to, None).unwrap();
+//! let proj = Proj::new_known_crs(from, to, None).unwrap();
 //!
 //! let result = proj.convert(donut_shop).unwrap();
 //!
@@ -191,7 +191,7 @@ let my_point = Point::new(4760096.421921f64, 3744293.729449f64);
 
 let from = "EPSG:2230";
 let to = "EPSG:26946";
-let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+let nad_ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
 
 let result = nad_ft_to_m.convert(my_point).unwrap();
 

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1242,6 +1242,12 @@ mod test {
     }
 
     #[test]
+    fn test_creation_from_string() {
+        let wgs84 = "+proj=longlat +datum=WGS84 +no_defs".to_owned();
+        Proj::new(wgs84).unwrap();
+    }
+
+    #[test]
     fn test_debug() {
         let wgs84 = "+proj=longlat +datum=WGS84 +no_defs";
         let proj = Proj::new(wgs84).unwrap();

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -186,7 +186,10 @@ fn area_set_bbox(parea: *mut proj_sys::PJ_AREA, new_area: Option<Area>) {
 }
 
 /// called by Proj::new and ProjBuilder::transform_new_crs
-fn transform_string(ctx: *mut PJ_CONTEXT, definition: &str) -> Result<Proj, ProjCreateError> {
+fn transform_string(
+    ctx: *mut PJ_CONTEXT,
+    definition: impl Into<Vec<u8>>,
+) -> Result<Proj, ProjCreateError> {
     let c_definition = CString::new(definition).map_err(ProjCreateError::ArgumentNulError)?;
     let ptr = result_from_create(ctx, unsafe { proj_create(ctx, c_definition.as_ptr()) })
         .map_err(|e| ProjCreateError::ProjError(e.message(ctx)))?;
@@ -200,8 +203,8 @@ fn transform_string(ctx: *mut PJ_CONTEXT, definition: &str) -> Result<Proj, Proj
 /// Called by new_known_crs and proj_known_crs
 fn transform_epsg(
     ctx: *mut PJ_CONTEXT,
-    from: &str,
-    to: &str,
+    from: impl Into<Vec<u8>>,
+    to: impl Into<Vec<u8>>,
     area: Option<Area>,
 ) -> Result<Proj, ProjCreateError> {
     let from_c = CString::new(from).map_err(ProjCreateError::ArgumentNulError)?;
@@ -523,7 +526,7 @@ impl Proj {
     // is signalled by the choice of enum used as input to the PJ_COORD union
     // PJ_LP signals projection of geodetic coordinates, with output being PJ_XY
     // and vice versa, or using PJ_XY for conversion operations
-    pub fn new(definition: &str) -> Result<Proj, ProjCreateError> {
+    pub fn new(definition: impl Into<Vec<u8>>) -> Result<Proj, ProjCreateError> {
         let ctx = unsafe { proj_context_create() };
         transform_string(ctx, definition)
     }
@@ -576,8 +579,8 @@ impl Proj {
     ///
     /// This method contains unsafe code.
     pub fn new_known_crs(
-        from: &str,
-        to: &str,
+        from: impl Into<Vec<u8>>,
+        to: impl Into<Vec<u8>>,
         area: Option<Area>,
     ) -> Result<Proj, ProjCreateError> {
         let ctx = unsafe { proj_context_create() };

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -401,7 +401,7 @@ impl ProjBuilder {
     ///
     /// # Safety
     /// This method contains unsafe code.
-    pub fn proj(mut self, definition: &str) -> Result<Proj, ProjCreateError> {
+    pub fn proj(mut self, definition: impl Into<Vec<u8>>) -> Result<Proj, ProjCreateError> {
         let ctx = unsafe { std::mem::replace(&mut self.ctx, proj_context_create()) };
         transform_string(ctx, definition)
     }
@@ -445,8 +445,8 @@ impl ProjBuilder {
     /// This method contains unsafe code.
     pub fn proj_known_crs(
         mut self,
-        from: &str,
-        to: &str,
+        from: impl Into<Vec<u8>>,
+        to: impl Into<Vec<u8>>,
         area: Option<Area>,
     ) -> Result<Proj, ProjCreateError> {
         let ctx = unsafe { std::mem::replace(&mut self.ctx, proj_context_create()) };

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -433,7 +433,7 @@ impl ProjBuilder {
     ///
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
-    /// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+    /// let nad_ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
     /// let result = nad_ft_to_m
     ///     .convert((4760096.421921f64, 3744293.729449f64))
     ///     .unwrap();
@@ -476,7 +476,7 @@ impl Default for ProjBuilder {
 ///
 /// let from = "EPSG:2230";
 /// let to = "EPSG:26946";
-/// let nad_ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+/// let nad_ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
 /// let result = nad_ft_to_m
 ///     .convert((4760096.421921f64, 3744293.729449f64))
 ///     .unwrap();
@@ -793,7 +793,7 @@ impl Proj {
     ///
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
-    /// let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+    /// let ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
     /// let result = ft_to_m
     ///     .convert((4760096.421921, 3744293.729449))
     ///     .unwrap();
@@ -858,7 +858,7 @@ impl Proj {
     /// // Convert from NAD83(NSRS2007) to NAD83(2011)
     /// let from = "EPSG:4759";
     /// let to = "EPSG:4317";
-    /// let NAD83_old_to_new = Proj::new_known_crs(&from, &to, None).unwrap();
+    /// let NAD83_old_to_new = Proj::new_known_crs(from, to, None).unwrap();
     /// let mut v = vec![
     ///     (-98.5421515000, 39.2240867222),
     ///     (-98.3166503906, 38.7112325390),
@@ -891,7 +891,7 @@ impl Proj {
     /// # use approx::assert_relative_eq;
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
-    /// let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+    /// let ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
     /// let mut v = vec![
     ///     (4760096.421921, 3744293.729449),
     ///     (4760197.421921, 3744394.729449),
@@ -939,7 +939,7 @@ impl Proj {
     ///
     /// let from = "EPSG:2230";
     /// let to = "EPSG:26946";
-    /// let ft_to_m = Proj::new_known_crs(&from, &to, None).unwrap();
+    /// let ft_to_m = Proj::new_known_crs(from, to, None).unwrap();
     /// let result = ft_to_m
     ///     .transform_bounds(4760096.421921, 3744293.729449, 4760196.421921, 3744393.729449, 21)
     ///     .unwrap();


### PR DESCRIPTION
`CString::new` takes any `Into<Vec<u8>>`, which includes `String`. This should make it possible to avoid reallocating when passing in an owned `String` with sufficient capacity.