### PR TITLE
Allow to use different versions of the libsqlite3-sys crate

### DIFF
--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -12,7 +12,7 @@ links = "proj"
 rust-version = "1.70"
 
 [dependencies]
-libsqlite3-sys = "0.28"
+libsqlite3-sys = ">=0.28,<0.31"
 link-cplusplus = "1.0"
 
 [build-dependencies]


### PR DESCRIPTION
I've opted to allow several different versions there instead of just bumping the supported version as that makes it much easier to use proj-sys in a complex project where other crates depend on libpsqlite3-sys as well. Cargo then will figure out the right version for all dependencies as long as there is a overlapping version.