### PR TITLE
Bump libsqlite3-sys to support version 0.32 as well

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Update build status badge
 - Update MSRV to 1.81
+- Add support for building with libsqlite3-sys 0.32
 
 ## 0.28.0 - 2024-12-20
 

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -12,7 +12,7 @@ links = "proj"
 rust-version = "1.70"
 
 [dependencies]
-libsqlite3-sys = ">=0.28,<0.32"
+libsqlite3-sys = ">=0.28,<0.33"
 link-cplusplus = "1.0.6"
 
 [build-dependencies]
@@ -33,3 +33,6 @@ buildtime_bindgen = ["dep:bindgen"]
 
 [package.metadata.docs.rs]
 features = [ "nobuild" ] # This feature will be enabled during the docs.rs build
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bundled_build)'] }


### PR DESCRIPTION
This commit increases the maximal supported libsqlite3-sys version to include 0.32 as well. It also fixes a warning about a unknown cfg by just adding it to the allow list as we set that via the build script.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
