### PR TITLE
Add method for epoch-enabled transformation pipeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # UNRELEASED
 - Add coordinate metadata creation and query functions
+- Add method for Proj creation from existing Proj instances, optionally containing epochs
 
 ## 0.29.0 - 2025-03-17
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,15 +79,15 @@
 //! There are two options for creating a transformation:
 //!
 //! 1. If you don't require additional [grids](#grid-file-download) or other customisation:
-//!     - Call `Proj::new` or `Proj::new_known_crs`. This creates a transformation instance ([`Proj`](proj/struct.Proj.html))
+//!     - Call [`Proj::new()`], [`Proj::new_known_crs()`] or [`Proj::create_crs_to_crs_from_pj()`].
+//!       This creates a transformation instance ([`Proj`])
 //! 2. If you require a grid for the transformation you wish to carry out, or you need to customise
 //!    the search path or the grid endpoint:
-//!    - Create a new [`ProjBuilder`](proj/struct.ProjBuilder.html) by calling
+//!    - Create a new [`ProjBuilder`] by calling
 //!      `ProjBuilder::new()`. It may be modified to enable network downloads, disable the grid,
 //!      cache or modify search paths;
-//!    - Call [`ProjBuilder.proj()`](proj/struct.ProjBuilder.html#method.proj) or
-//!      [`ProjBuilder.proj_known_crs()`](proj/struct.ProjBuilder.html#method.proj_known_crs). This
-//!      creates a transformation instance (`Proj`)
+//!    - Call [`ProjBuilder::proj()`], [`ProjBuilder::proj_known_crs()`], or
+//!     [`ProjBuilder::proj_create_crs_to_crs_from_pj()`]. This creates a transformation instance ([`Proj`])
 //!
 //! **Note**:
 //!


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

<s>Draft for now, </s>pls land #226 first.