### PR TITLE
Update network (grid download) functionality to use ureq 3.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 - Add coordinate metadata creation and query functions
 - Add method for Proj creation from existing Proj instances, optionally containing epochs
+- Update ureq to 3.x and adapt network functionality to its new API
 
 ## 0.29.0 - 2025-03-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ rust-version = "1.82"
 [dependencies]
 proj-sys = { version = "0.25.0", path = "proj-sys" }
 geo-types = { version = "0.7.10", optional = true }
-libc = "0.2.119"
+libc = "0.2.172"
 num-traits = "0.2.14"
 thiserror = "2.0.0"
-ureq = { version = "2.0.0", optional = true }
+ureq = { version = "3.0.11", optional = true }
+http = { version = "1.3.0", optional = true }
 
 [workspace]
 members = ["proj-sys"]
@@ -29,7 +30,7 @@ members = ["proj-sys"]
 default = ["geo-types"]
 bundled_proj = [ "proj-sys/bundled_proj" ]
 pkg_config = [ "proj-sys/pkg_config" ]
-network = ["ureq", "proj-sys/network"]
+network = ["ureq", "http", "proj-sys/network"]
 
 [dev-dependencies]
 # approx version must match the one used in geo-types


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

<s>No changelog entry yet since we have other PRs in flight.</s>

This was an unfun piece of work as the ureq API has evolved significantly between 2.x and 3.0, and the way we're passing the connection pool object around is more difficult to do now. That having been said the tests pass and none of the changes affect the public API. We also have a new optional dep in the form of `http`, but I suspect it was present previously anyway.