### PR TITLE
Update proj-sys flate2 dep for ureq 3.x compatibility

### DIFF
--- a/proj-sys/CHANGES.md
+++ b/proj-sys/CHANGES.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 - Update to PROJ 9.6.0
+- Update flate2 dependency for ureq 3.x compat
 
 # 0.25.0 - 2024-12-20
 

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -19,7 +19,7 @@ link-cplusplus = "1.0.6"
 bindgen = { version = "0.71.1", optional = true }
 pkg-config = "0.3.25"
 cmake = "0.1.50"
-flate2 = "1.0.24"
+flate2 = "1.1.1"
 tar = "0.4.40"
 
 [features]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

We're using an older flate2 version that won't be accepted by ureq 3.x (see #228).
