### PR TITLE
Prepare for proj-sys v0.26.0 and proj v0.30.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
-# UNRELEASED
+# 0.30.0 - 2025-04-18
+
 - Add coordinate metadata creation and query functions
 - Add method for Proj creation from existing Proj instances, optionally containing epochs
 - Update ureq to 3.x and adapt network functionality to its new API

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.82"
 
 [dependencies]
-proj-sys = { version = "0.25.0", path = "proj-sys" }
+proj-sys = { version = "0.26.0", path = "proj-sys" }
 geo-types = { version = "0.7.10", optional = true }
 libc = "0.2.172"
 num-traits = "0.2.14"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ There are two options for creating a transformation:
 
 ## Requirements
 
-By default, the crate requires `libproj` 9.2.x to be present on your system. While it may be
+By default, the crate requires `libproj` 9.6.x to be present on your system. While it may be
 backwards-compatible with older PROJ 6 versions, this is neither tested nor supported. If a suitable library can't be found, `proj` will attempt to build `libproj` from source.
 
 ## Feature Flags

--- a/proj-sys/CHANGES.md
+++ b/proj-sys/CHANGES.md
@@ -1,7 +1,8 @@
-# UNRELEASED
+# 0.26.0 - 2025-04-18
 
 - Update to PROJ 9.6.0
 - Update flate2 dependency for ureq 3.x compat
+- Bump MSRV to 1.82
 
 # 0.25.0 - 2024-12-20
 

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proj-sys"
 description = "Rust bindings for PROJ v9.6.x"
 repository = "https://github.com/georust/proj"
-version = "0.25.0"
+version = "0.26.0"
 readme = "README.md"
 authors = ["The Georust developers <mods@georust.org>"]
 keywords = ["proj", "projection", "osgeo", "geo", "geospatial"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
-//! Coordinate transformation via bindings to the [PROJ](https://proj.org) v9.4.x API.
+//! Coordinate transformation via bindings to the [PROJ](https://proj.org) v9.6.x API.
 //!
 //! Two coordinate transformation operations are currently provided: _projection_ (and inverse
 //! projection) and _conversion_.
@@ -9,7 +9,7 @@
 //! projected coordinate systems. The PROJ [documentation](https://proj.org/operations/index.html)
 //! explains the distinction between these operations in more detail.
 //!
-//! This crate depends on [`libproj v9.4.x`](https://proj.org), accessed via the
+//! This crate depends on [`libproj v9.6.x`](https://proj.org), accessed via the
 //! [`proj-sys`](https://docs.rs/proj-sys) crate. By default, `proj-sys` will try to find a
 //! pre-existing installation of libproj on your system. If an appropriate version of libproj
 //! cannot be found, the build script will attempt to build libproj from source. You may specify a
@@ -98,7 +98,7 @@
 //!
 //! # Requirements
 //!
-//! By default, the crate requires `libproj` 9.2.x to be present on your system and will use `pkg-config`
+//! By default, the crate requires `libproj` 9.6.x to be present on your system and will use `pkg-config`
 //! to attempt to locate it. If this fails, the crate will attempt to build libproj from its bundled source.
 //!
 //! # Feature Flags


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

This updates libproj to v9.6.0, and bumps the `proj` MSRV to 1.82 (released 6 months ago)
I'd like to release these tomorrow (2025-04-18).