### PR TITLE
Add a daily scheduled test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
       - trying
   pull_request:
   merge_group:
+  schedule: [cron: "45 6 * * *"]
 
 env:
   LIBPROJ_VERSION: 9.6.0


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

This is the same schedule as `geo`. Given that we've had some dependencies break the build recently, it'd be good to know sooner rather than later.