### PR TITLE
Update version constraint libsqlite3-sys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 - Add Proj::as_wkt() function
+- Add support for building with libsqlite3-sys 0.33, 0.34
 
 # 0.30.0 - 2025-04-18
 

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -12,7 +12,7 @@ links = "proj"
 rust-version = "1.82"
 
 [dependencies]
-libsqlite3-sys = ">=0.28,<0.33"
+libsqlite3-sys = ">=0.28,<0.35"
 link-cplusplus = "1.0.6"
 
 [build-dependencies]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

I'm wondering why the `<0.33` constraint was in place in the first place. Is there any reason for this? I checked the [build requirements for Proj](https://proj.org/en/stable/install.html), and they only mention that `SQLite3 >= 3.11` is required. Were there build failures in the past?

If possible, I'd like to remove this constraint so it's easier to use proj in projects that also use SQLite.