### PR TITLE
Prepare for 0.31.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.31.0 - 2025-08-29
+
 - Add Proj::as_wkt() function
 - Update to proj-sys 0.27.0:
   - Update to PROJ 9.6.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "High-level Rust bindings for the latest stable version of PROJ"
-version = "0.30.0"
+version = "0.31.0"
 authors = [
     "The Georust Developers <mods@georust.org>"
 ]


### PR DESCRIPTION
Incorporating proj-sys 0.27.0 (libproj 9.6.2)

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
