### PR TITLE
Fix buffer overflow and nul-byte replacement in error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Add fixes for buffer overflow and incorrect char replacement 
 
 - Refactored options logic
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -164,10 +164,12 @@ pub(crate) unsafe extern "C" fn network_open(
         #[allow(clippy::ptr_as_ptr)]
         Err(e) => {
             let err_string = e.to_string();
+            let len = err_string
+                .len()
+                .min(error_string_max_size.saturating_sub(1));
             unsafe {
-                out_error_string
-                    .copy_from_nonoverlapping(err_string.as_ptr().cast(), err_string.len());
-                out_error_string.add(err_string.len()).write(0);
+                out_error_string.copy_from_nonoverlapping(err_string.as_ptr().cast(), len);
+                out_error_string.add(len).write(0);
             }
             ptr::null_mut()
         }
@@ -352,15 +354,15 @@ pub(crate) unsafe extern "C" fn network_read_range(
     ) {
         Ok(res) => res,
         Err(e) => {
-            // The assumption here is that if 0 is returned, whatever error is in out_error_string is displayed by libproj
-            // since this isn't a conversion using CString, nul chars must be manually stripped
-            let err_string = e.to_string().replace('0', "nought");
+            let err_string = CString::new(e.to_string()).unwrap_or(
+                c"Error while buildling error message: Unable to report error specifics".into(),
+            );
+            let bytes = &err_string.as_bytes_with_nul();
+            let len = bytes.len().min(error_string_max_size);
             unsafe {
-                out_error_string
-                    .copy_from_nonoverlapping(err_string.as_ptr().cast(), err_string.len());
-                out_error_string.add(err_string.len()).write(0);
+                out_error_string.copy_from_nonoverlapping(bytes.as_ptr().cast(), len);
             }
-            0usize
+            0
         }
     }
 }


### PR DESCRIPTION
- Add bounds checking using error_string_max_size before writing error strings
- Fix incorrect character replacement: use '\0' (nul byte) instead of '0' (digit)

NB: this PR is tool-assisted (Claude Opus 4.5)

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
