### PR TITLE
Add bundled_proj_sqlite feature to support windows-msvc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
       - proj-sys-ubuntu
       - proj-macos
       - proj-sys-macos
+      - proj-windows
     steps:
       - name: Mark the job as a success
         run: exit 0
@@ -58,6 +59,7 @@ jobs:
       - proj-sys-ubuntu
       - proj-macos
       - proj-sys-macos
+      - proj-windows
     steps:
       - name: Mark the job as a failure
         run: exit 1
@@ -202,3 +204,18 @@ jobs:
       - run: brew install pkg-config
       - run: brew install proj
       - run: cargo test
+
+  proj-windows:
+    name: proj windows
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Currently, Windows build doesn't work without the bundled features.
+        features: ["--features bundled_proj_sqlite"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - run: cargo build ${{ matrix.features }}
+      - run: cargo test ${{ matrix.features }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,5 +217,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - run: choco install sqlite # Even if we bundle libsqlite, we still need the SQLite binary
       - run: cargo build ${{ matrix.features }}
       - run: cargo test ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = ["proj-sys"]
 [features]
 default = ["geo-types"]
 bundled_proj = [ "proj-sys/bundled_proj" ]
+bundled_proj_sqlite = [ "proj-sys/bundled_proj_sqlite" ]
 pkg_config = [ "proj-sys/pkg_config" ]
 network = ["ureq", "http", "proj-sys/network"]
 

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -24,7 +24,8 @@ tar = "0.4.40"
 
 [features]
 nobuild = []
-bundled_proj = ["libsqlite3-sys/bundled-windows"]
+bundled_proj = []
+bundled_proj_sqlite = ["bundled_proj", "libsqlite3-sys/bundled"]
 # `pkg_config` feature is deprecated and does nothing
 pkg_config = []
 network = ["tiff"]

--- a/proj-sys/Cargo.toml
+++ b/proj-sys/Cargo.toml
@@ -24,7 +24,7 @@ tar = "0.4.40"
 
 [features]
 nobuild = []
-bundled_proj = []
+bundled_proj = ["libsqlite3-sys/bundled-windows"]
 # `pkg_config` feature is deprecated and does nothing
 pkg_config = []
 network = ["tiff"]

--- a/proj-sys/build.rs
+++ b/proj-sys/build.rs
@@ -46,6 +46,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })?
     };
 
+    // Link Windows system libs, which are used in cargo test
+    if cfg!(target_env = "msvc") {
+        println!("cargo:rustc-link-lib=ole32");
+        println!("cargo:rustc-link-lib=shell32");
+    }
+
     #[cfg(feature = "buildtime_bindgen")]
     generate_bindings(include_path)?;
     #[cfg(not(feature = "buildtime_bindgen"))]

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1357,14 +1357,9 @@ impl Proj {
             None
         };
 
-        let opts_ptrs = options_str.as_ref().map(|o| {
-            // Each option is a CString (null-terminated string), but PROJ also expects
-            // the *array* of option pointers itself to be null-terminated (char* const*).
-            let mut ptrs: Vec<_> = o.iter().map(|cs| cs.as_ptr()).collect();
-            // Add a trailing NULL pointer to terminate the list.
-            ptrs.push(ptr::null());
-            ptrs
-        });
+        let opts_ptrs = options_str
+            .as_ref()
+            .map(|o| o.iter().map(|cs| cs.as_ptr()).collect::<Vec<_>>());
 
         let wkt_type = match version.unwrap_or(WktVersion::Wkt2_2019) {
             WktVersion::Wkt2_2015 => PJ_WKT_TYPE_PJ_WKT2_2015,

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1357,9 +1357,14 @@ impl Proj {
             None
         };
 
-        let opts_ptrs = options_str
-            .as_ref()
-            .map(|o| o.iter().map(|cs| cs.as_ptr()).collect::<Vec<_>>());
+        let opts_ptrs = options_str.as_ref().map(|o| {
+            // Each option is a CString (null-terminated string), but PROJ also expects
+            // the *array* of option pointers itself to be null-terminated (char* const*).
+            let mut ptrs: Vec<_> = o.iter().map(|cs| cs.as_ptr()).collect();
+            // Add a trailing NULL pointer to terminate the list.
+            ptrs.push(ptr::null());
+            ptrs
+        });
 
         let wkt_type = match version.unwrap_or(WktVersion::Wkt2_2019) {
             WktVersion::Wkt2_2015 => PJ_WKT_TYPE_PJ_WKT2_2015,

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1769,8 +1769,8 @@ mod test {
         let t = stereo70
             .project(MyPoint::new(500119.70352012233, 500027.77896348457), true)
             .unwrap();
-        assert_relative_eq!(t.x(), 0.43633200013698786);
-        assert_relative_eq!(t.y(), 0.8028510000110507);
+        assert_relative_eq!(t.x(), 0.436332000136988, epsilon = 1e-15);
+        assert_relative_eq!(t.y(), 0.802851000011051, epsilon = 1e-15);
     }
     #[test]
     // Carry out an inverse projection to geodetic coordinates


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

In order to make proj-sys work on Windows (more specifically, `windows-msvc`. I don't know well about `windows-gnu`), I found there are at least two options.

1. Use vcpkg to install PROJ
2. Bundle PROJ including SQLite

(I don't describe the details about first option, but here's what it looks like: https://github.com/MIERUNE/point-tiler/pull/64)

For the second option, the proj crate and proj-sys crate already exposes `bundled_proj`, but I found it's not enough on Windows' case, where we usually doesn't have SQLite installed. So, this pull request adds a feature flag `bundled_proj_sqlite` to expose the libsqlite3-sys's `bundled` feature in order to bundle SQLite as well.

That's all of this pull request, but I have to explain about some tricky things:

- PROJ uses the SQLite executable as well as the library (cf. <https://proj.org/en/stable/install.html#build-requirements>). So, even if we use `bundled_proj_sqlite`, we need to install SQLite on the GHA CI.
- For some reason, `cargo test` requires some Windows system libraries, otherwise it fails with the following error. So, I added these in `build.rs`.  
  ```
  = note: libproj_sys-119818f7f11b3538.rlib(filemanager.obj) : error LNK2019: unresolved external symbol __imp_CoTaskMemFree referenced in function proj_context_get_user_writable_directory␍
          libproj_sys-119818f7f11b3538.rlib(filemanager.obj) : error LNK2019: unresolved external symbol SHGetKnownFolderPath referenced in function proj_context_get_user_writable_directory␍
  ```
- ~~The `proj::test::test_inverse_projection` test reliably fails with `STATUS_ACCESS_VIOLATION`. I'm yet to figure out what this error is.~~ (fixed now)