### PR TITLE
Fix linker error in windows/msys2

### DIFF
--- a/proj-sys/build.rs
+++ b/proj-sys/build.rs
@@ -153,6 +153,10 @@ fn build_from_source() -> Result<std::path::PathBuf, Box<dyn std::error::Error>>
     } else {
         println!("cargo:rustc-link-lib=static=proj");
     }
+    // link against shell32 on windows/msys2.
+    if cfg!(all(target_os = "windows", target_env = "gnu")) {
+        println!("cargo:rustc-link-lib=dylib=shell32");
+    }
     println!(
         "cargo:rustc-link-search=native={}",
         proj.join("lib").display()


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

There is a linker error when trying to use proj from windows with the windows-gnu target. It complains about a missing function `__imp_SHGetFolderPathW`:

```
error: linking with `x86_64-w64-mingw32-gcc` failed: exit code: 1
  |
  = note: "x86_64-w64-mingw32-gcc" "-fno-use-linker-plugin" "-Wl,--dynamicbase" "-Wl,--disable-auto-image-base" "-m64" "-Wl,--high-entropy-va" "C:\\msys64\\tmp\\rustcMab6mY\\symbols.o" "<21 object files omitted>" "-Wl,-Bstatic" "C:\\msys64\\home\\username\\proj\\target\\debug\\deps/{libproj-76b465033444864d,libthiserror-2309492b851a5360,libproj_sys-c0aba6b6168d3f07,liblink_cplusplus-c9478adf1c7d2674,liblibsqlite3_sys-8ae3b369c984db8e,liblibc-1dc5d3c41f5ac71c,libgeo_types-2247939a934095e7,libapprox-cb34ff0110c7c709,libnum_traits-120be4504cb220d8}.rlib" "<sysroot>\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,libwindows_targets-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lstdc++" "-lsqlite3" "-lkernel32" "-lkernel32" "-lkernel32" "-lntdll" "-luserenv" "-lws2_32" "-ldbghelp" "-lgcc_eh" "-l:libpthread.a" "-lmsvcrt" "-lmingwex" "-lmingw32" "-lgcc" "-lmsvcrt" "-lmingwex" "-luser32" "-lkernel32" "-Wl,--nxcompat" "-L" "C:\\msys64\\home\\username\\proj\\target\\debug\\build\\proj-sys-2e6d984bbc46329d\\out\\lib" "-L" "C:\\msys64\\home\\username\\proj\\target\\debug\\build\\proj-sys-2e6d984bbc46329d\\out\\lib64" "-L" "C:\\msys64\\home\\username\\proj\\target\\debug\\build\\proj-sys-2e6d984bbc46329d\\out\\build/lib" "-L" "C:\\msys64\\home\\username\\proj\\target\\debug\\build\\link-cplusplus-63559f5facd61310\\out" "-o" "C:\\msys64\\home\\username\\proj\\target\\debug\\examples\\simple-770bfc3e93b23f63.exe" "-Wl,--gc-sections" "-no-pie" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\msys64\home\username\proj\target\debug\deps\libproj_sys-c0aba6b6168d3f07.rlib(filemanager.cpp.obj): in function `proj_context_get_user_writable_directory':␍
          C:/msys64/home/username/proj/target/debug/build/proj-sys-2e6d984bbc46329d/out/PROJSRC/proj/proj-9.6.2/src/filemanager.cpp:1271:(.text$proj_context_get_user_writable_directory+0xec): undefined reference to `__imp_SHGetFolderPathW'␍
          collect2.exe: error: ld returned 1 exit status

  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)
```

It is fixed by explicitely linking to the shell32 library (which is present in any windows installation).