### PR TITLE
Don't call proj_cleanup() on every Drop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 - Add fixes for buffer overflow and incorrect char replacement
 - Persist network client between requests, which should speed up grid
   operations that require multiple network requests.
+- No longer free PROJ's process-global resource caches (grids and `+init`
+  files) when a `Proj` or `ProjBuilder` is dropped. These caches persist for
+  the lifetime of the process, substantially speeding up repeated creation of
+  transformation objects (https://github.com/georust/proj/issues/256).
 
 - Refactored options logic
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,12 @@ network = ["ureq", "http", "proj-sys/network"]
 [dev-dependencies]
 # approx version must match the one used in geo-types
 approx = "0.5"
+criterion = "0.7"
 geo-types = { version = "0.7.16", features = ["approx"] }
+
+[[bench]]
+name = "proj_creation"
+harness = false
 
 [package.metadata.docs.rs]
 features = [ "proj-sys/nobuild", "network", "geo-types" ]

--- a/benches/proj_creation.rs
+++ b/benches/proj_creation.rs
@@ -1,0 +1,16 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use proj::Proj;
+
+// Cost of constructing a transformation object. Each `Proj::new` creates its own PROJ context,
+// so this is dominated by context setup rather than the projection itself.
+// See https://github.com/georust/proj/issues/256
+fn proj_creation(c: &mut Criterion) {
+    c.bench_function("Proj::new EPSG:4326", |b| {
+        b.iter(|| Proj::new(black_box("EPSG:4326")).unwrap());
+    });
+}
+
+criterion_group!(benches, proj_creation);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,19 @@
 //! The path used to search for resource files can be modified using
 //! [`set_search_paths`](proj/struct.ProjBuilder.html#method.set_search_paths)
 //!
+//! ### Resource Caching
+//! Separately from the on-disk [Grid File Cache](#grid-file-cache) described above, PROJ keeps
+//! process-global caches of resources *in memory*: grids that have been loaded, and the contents
+//! of `+init` files. These caches are shared across all `Proj` and `ProjBuilder` instances and
+//! persist for the lifetime of the process; they are not released when individual instances are
+//! dropped. Repeated creation of transformation objects therefore reuses already-loaded resources
+//! rather than reading them from disk again.
+//!
+//! These in-memory caches are never explicitly freed, so they remain resident until the process
+//! exits, at which point the operating system reclaims them. They are bounded by the set of
+//! resources actually loaded and so do not grow without bound: the cost is memory residency for
+//! the lifetime of the process, not additional disk usage.
+//!
 //! ## Conform your own types
 //!
 //! If you have your own geometric types, you can conform them to the `Coord` trait and use `proj`

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -6,8 +6,8 @@ use proj_sys::{
     PJ_WKT_TYPE_PJ_WKT1_ESRI, PJ_WKT_TYPE_PJ_WKT1_GDAL, PJ_WKT_TYPE_PJ_WKT2_2015,
     PJ_WKT_TYPE_PJ_WKT2_2015_SIMPLIFIED, PJ_WKT_TYPE_PJ_WKT2_2019,
     PJ_WKT_TYPE_PJ_WKT2_2019_SIMPLIFIED, PJ_XYZT, PJconsts, proj_area_create, proj_area_destroy,
-    proj_area_set_bbox, proj_as_projjson, proj_as_wkt, proj_cleanup, proj_context_clone,
-    proj_context_create, proj_context_destroy, proj_context_errno, proj_context_get_url_endpoint,
+    proj_area_set_bbox, proj_as_projjson, proj_as_wkt, proj_context_clone, proj_context_create,
+    proj_context_destroy, proj_context_errno, proj_context_get_url_endpoint,
     proj_context_is_network_enabled, proj_context_set_search_paths, proj_context_set_url_endpoint,
     proj_coordinate_metadata_create, proj_coordinate_metadata_get_epoch, proj_create,
     proj_create_crs_to_crs, proj_create_crs_to_crs_from_pj, proj_destroy, proj_errno_string,
@@ -1459,9 +1459,11 @@ impl Drop for Proj {
             }
             proj_destroy(self.c_proj);
             proj_context_destroy(self.ctx);
-            // NB do NOT call until proj_destroy and proj_context_destroy have both returned:
-            // https://proj.org/development/reference/functions.html#c.proj_cleanup
-            proj_cleanup()
+            // We deliberately do not call proj_cleanup() here. It frees PROJ's
+            // process-global resources (the grid and +init file caches), so calling
+            // it whenever a single object is dropped clears caches that the next
+            // object would otherwise reuse, forcing reloads from disk. PROJ intends
+            // it to be called once before process termination, not per object.
         }
     }
 }
@@ -1470,7 +1472,6 @@ impl Drop for ProjBuilder {
     fn drop(&mut self) {
         unsafe {
             proj_context_destroy(self.ctx);
-            proj_cleanup()
         }
     }
 }


### PR DESCRIPTION
proj_cleanup() frees PROJ's process-global caches (grids, +init files), so calling it on each Proj/ProjBuilder drop clears caches the next object would reuse, forcing reloads from disk. Removing it drops Proj::new cost by ~10x

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

See #256. We're still a long way off c / cpp perf, but this is a minor intervention for a lot of perf.